### PR TITLE
Fix prod-promote workflow

### DIFF
--- a/almahook_ecr.tf
+++ b/almahook_ecr.tf
@@ -59,7 +59,8 @@ output "alma_webhook_lambdas_prod_promote_workflow" {
     region     = var.aws_region
     role_stage = "${module.ecr_alma_webhook_lambdas.repo_name}-gha-stage"
     role_prod  = "${module.ecr_alma_webhook_lambdas.repo_name}-gha-prod"
-    ecr        = module.ecr_alma_webhook_lambdas.repository_name
+    ecr_stage  = "${module.ecr_alma_webhook_lambdas.repo_name}-stage"
+    ecr_prod   = "${module.ecr_alma_webhook_lambdas.repo_name}-prod"
     function   = local.ecr_alma_webhook_lambdas_function_name
     }
   )

--- a/files/fargate-prod-promote.tpl
+++ b/files/fargate-prod-promote.tpl
@@ -1,4 +1,4 @@
-### This is the Terraform-generated prod-promote.yml workflow for the ${ecr} app repository ###
+### This is the Terraform-generated prod-promote.yml workflow for the ${ecr_prod} app repository ###
 name: Prod Promote Fargate Container
 on:
   workflow_dispatch:
@@ -14,4 +14,5 @@ jobs:
       AWS_REGION: "${region}"
       GHA_ROLE_STAGE: ${role_stage}
       GHA_ROLE_PROD: ${role_prod}
-      ECR: "${ecr}"
+      ECR_STAGE: "${ecr_stage}"
+      ECR_PROD: "${ecr_prod}"

--- a/files/lambda-prod-promote.tpl
+++ b/files/lambda-prod-promote.tpl
@@ -14,6 +14,7 @@ jobs:
       AWS_REGION: "${region}"
       GHA_ROLE_STAGE: ${role_stage}
       GHA_ROLE_PROD: ${role_prod}
-      ECR: "${ecr}"
+      ECR_STAGE: "${ecr_stage}"
+      ECR_PROD: "${ecr_prod}"
       FUNCTION: "${function}"
  

--- a/modules/ecr/main.tf
+++ b/modules/ecr/main.tf
@@ -48,10 +48,15 @@ data "aws_iam_policy_document" "rw_this" {
   statement {
     actions = [
       "ecr:BatchCheckLayerAvailability",
+      "ecr:BatchGetImage",
       "ecr:CompleteLayerUpload",
       "ecr:DeleteRepository",
       "ecr:DescribeImages",
+      "ecr:DescribeImageScanFindings",
       "ecr:DescribeRepositories",
+      "ecr:GetDownloadUrlForLayer",
+      "ecr:GetLifecyclePolicy",
+      "ecr:GetLifecyclePolicyPreview",
       "ecr:InitiateLayerUpload",
       "ecr:ListImages",
       "ecr:ListTagsForResource",

--- a/ppod_ecr.tf
+++ b/ppod_ecr.tf
@@ -58,7 +58,8 @@ output "ppod_prod_promote_workflow" {
     region     = var.aws_region
     role_stage = "${module.ecr_ppod.repo_name}-gha-stage"
     role_prod  = "${module.ecr_ppod.repo_name}-gha-prod"
-    ecr        = module.ecr_ppod.repository_name
+    ecr_stage  = "${module.ecr_ppod.repo_name}-stage"
+    ecr_prod   = "${module.ecr_ppod.repo_name}-prod"
     function   = local.ecr_ppod_function_name
     }
   )

--- a/timdex_ecrs.tf
+++ b/timdex_ecrs.tf
@@ -52,7 +52,8 @@ output "mario_prod_promote_workflow" {
     region     = var.aws_region
     role_stage = "${module.ecr_mario.repo_name}-gha-stage"
     role_prod  = "${module.ecr_mario.repo_name}-gha-prod"
-    ecr        = module.ecr_mario.repository_name
+    ecr_stage  = "${module.ecr_mario.repo_name}-stage"
+    ecr_prod   = "${module.ecr_mario.repo_name}-prod"
     }
   )
   description = "Full contents of the prod-promote.yml for the mario repo"
@@ -107,7 +108,8 @@ output "oaiharvester_prod_promote_workflow" {
     region     = var.aws_region
     role_stage = "${module.ecr_oaiharvester.repo_name}-gha-stage"
     role_prod  = "${module.ecr_oaiharvester.repo_name}-gha-prod"
-    ecr        = module.ecr_oaiharvester.repository_name
+    ecr_stage  = "${module.ecr_oaiharvester.repo_name}-stage"
+    ecr_prod   = "${module.ecr_oaiharvester.repo_name}-prod"
     }
   )
   description = "Full contents of the prod-promote.yml for the oaiharvester repo"
@@ -161,7 +163,8 @@ output "transmogrifier_prod_promote_workflow" {
     region     = var.aws_region
     role_stage = "${module.ecr_timdex_transmogrifier.repo_name}-gha-stage"
     role_prod  = "${module.ecr_timdex_transmogrifier.repo_name}-gha-prod"
-    ecr        = module.ecr_timdex_transmogrifier.repository_name
+    ecr_stage  = "${module.ecr_timdex_transmogrifier.repo_name}-stage"
+    ecr_prod   = "${module.ecr_timdex_transmogrifier.repo_name}-prod"
     }
   )
   description = "Full contents of the prod-promote.yml for the transmogrifier repo"
@@ -223,7 +226,8 @@ output "timdex_lambdas_prod_promote_workflow" {
     region     = var.aws_region
     role_stage = "${module.ecr_timdex_lambdas.repo_name}-gha-stage"
     role_prod  = "${module.ecr_timdex_lambdas.repo_name}-gha-prod"
-    ecr        = module.ecr_timdex_lambdas.repository_name
+    ecr_stage  = "${module.ecr_timdex_lambdas.repo_name}-stage"
+    ecr_prod   = "${module.ecr_timdex_lambdas.repo_name}-prod"
     function   = local.ecr_timdex_lambdas_function_name
     }
   )


### PR DESCRIPTION
#### Developer Checklist

- [X] The README contains any additional info needed outside of the terraform docs generated
- [X] Any special variables have values configured in AWS SSM
- [X] Stakeholder approval has been confirmed (or is not needed)

#### What does this PR do?

* Add additional variables to the prod-promote caller workflow
* Update the `prod-promote.yml` caller workflow template files to match the additional variables
* Add the `ecr:BatchGetImage` and a few other actions to the policy that the OIDC/GHA role


#### Helpful background context

The prod-promote automation failed for multiple reasons. There are fixes in the [.github](https://github.com/MITLibraries/.github/pull/12) repo shared workflow. Those fixes require updates to the `prod-promote.yml` text in the Terraform output from this repo. And there are IAM policies changes needed.

See https://github.com/MITLibraries/.github/pull/12.

#### What are the relevant tickets?

* https://mitlibraries.atlassian.net/browse/ENSY-81
* https://mitlibraries.atlassian.net/browse/ENSY-87
* https://mitlibraries.atlassian.net/browse/ENSY-77
* https://mitlibraries.atlassian.net/browse/ENSY-78

#### Requires Database Migrations?

NO

#### Includes new or updated dependencies?

NO
