### PR TITLE
Fix Fargate dev deploy

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,10 @@ The [ppod_ecr.tf](./ppod_ecr.tf) is a good example of a single ECR repository fo
 
 **Note**: For Lambda function ECRs, it is imperative that the Infra engineer coordinates with the software engineer to determine the name of the Lambda function as part of the creation of the ECR by this repository.
 
+## For Application Developers
+
+A quick note for application developers and the integration of workflows to automate the deployment of their containerized application to either Fargate or Lambda. When this code is deployed in Terraform Cloud, it generates outputs that contain the caller workflows code as well as the `Makefile` code for their application. Those outputs are accessible to the developers via Terraform Cloud -- they can go into TfC, find the correct Terraform Output, and then copy that text into their application repository.
+
 ## TF markdown is automatically inserted at the bottom of this file, nothing should be written beyond this point
 
 <!-- BEGIN_TF_DOCS -->

--- a/files/fargate-dev-build.tpl
+++ b/files/fargate-dev-build.tpl
@@ -2,7 +2,7 @@
 name: Dev Build and Deploy Fargate Container
 on:
   workflow_dispatch:
-  push:
+  pull_request:
     branches:
       - main
     paths-ignore:


### PR DESCRIPTION
#### Developer Checklist

- [X] The README contains any additional info needed outside of the terraform docs generated
- [X] Any special variables have values configured in AWS SSM
- [X] Stakeholder approval has been confirmed (or is not needed)

#### What does this PR do?

* Update the dev_build template for Fargate to only trigger on pull requests
* Update the README with a note to developers about accessing the Terraform outputs


#### Helpful background context

The Fargate dev builds were incorrectly triggering on a push to `main`, not a pull-request on `main`. This fixes that so that Fargate builds are handled the same way as Lambda builds.

**Note**: This **only** affects the outputs in the `workloads-ecr-dev` TfC workspace.

#### Requires Database Migrations?

NO

#### Includes new or updated dependencies?

NO
