### PR TITLE
Add GIS-related ECRs and update Matomo ECR in Prod-Workloads

### DIFF
--- a/.terraform.lock.hcl
+++ b/.terraform.lock.hcl
@@ -2,21 +2,21 @@
 # Manual edits may be lost in future updates.
 
 provider "registry.terraform.io/hashicorp/aws" {
-  version     = "3.75.1"
-  constraints = "~> 3.0"
+  version     = "4.26.0"
+  constraints = "~> 4.0"
   hashes = [
-    "h1:KH2z3YjNuXa+Konx4W6Za2vu581E/9VaV7kNTkZw9mU=",
-    "h1:zgO9MSF32Rz6lOBumY+FyPZESYwlL5SUXOViTV5cs28=",
-    "zh:11c2ee541ca1da923356c9225575ba294523d7b6af82d6171c912470ef0f90cd",
-    "zh:19fe975993664252b4a2ff1079546f2b186b01d1a025a94a4f15c37e023806c5",
-    "zh:442e7fc145b2debebe9279b283d07f5f736dc1776c2e5b1702728a6eb03789d0",
-    "zh:7a77991b204ae2c16ac29a32226135d5fdbda40c8dafa77c5adf5439a346be77",
-    "zh:89a257933181c15293c15a858fbfe7252129cc57cc2ec05b6c0b595d1bfe9d38",
-    "zh:b1813ea5b6b0fd88ea85b1b21b8e4119566d1bc34feca297b4fb39d0536893cb",
-    "zh:c519f3292ae431bd2381f88a95bd37c52f7a56d91feef88511e929344c180549",
-    "zh:d3dbe88b661c073c174f04f73adc2720372143bdfa12f4fe8f411332e64662cf",
-    "zh:e92a27e3c7295b031b5d62dd9428966c96e3157fc768b3d848a9ac60d1661c8e",
-    "zh:ecd664c0d664fcf2d8a89a01462cb00bcae37da200305aef2de1b8fe185c9cd8",
-    "zh:ed6ce1f9fa96aa28dd65842f852abed25f919d20b5cf53d26cec5b3f4d845725",
+    "h1:q0QTY+O5L//LGGkmlUlEvTLnNSsdV91Tqm7BFqwpSII=",
+    "zh:0579b105ae471894846fbd740bc9f10b2bd8a48860d8e640b4a9b53fb7d63ffe",
+    "zh:0ce445cfbffb6c0eee9e0e2a95850b5749d56aa8211b95a686c24dc2847a36ea",
+    "zh:41f0cf0810363cea4e54f3d9c452f2eb77123bcdaacc18b978c825496168cae2",
+    "zh:431a7e967b5c9d7ebde6c714abedd9464be6a62f7eafa1808a86a8bd92851317",
+    "zh:4afebd3c3a8c0646f0874493840b6f8c82f7f4302780faec5c7b0c616077eebe",
+    "zh:7f077662efc8d7b91ef604999daf6b45a968cb2f5d8c4512a00d2feb4db05a7a",
+    "zh:9a58d1ef049ccaa9615fe5722ba815065f45d172f8bc656ffdbab4ca16f6b786",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9d30b70a2daa0d94661590f6533e07071d2c7052b8279f05090f1bf037f56607",
+    "zh:b75f88be5d048849a632895d43b836ed1693031e586cd873ee915b5d3cf4fae6",
+    "zh:c57ac099b01fe49dd4e1e4674a06f61029fa6316e4f92a6a2a3bdc0444b371f9",
+    "zh:cb48a175ebb2a12fecae7dc6580bf88fbcf5408cdc53f3cf057150ebe9144034",
   ]
 }

--- a/README.md
+++ b/README.md
@@ -38,28 +38,34 @@ A quick note for application developers and the integration of workflows to auto
 
 | Name | Version |
 |------|---------|
-| terraform | ~> 1.1 |
-| aws | ~> 3.0 |
+| terraform | ~> 1.2 |
+| aws | ~> 4.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| aws | 3.75.1 |
+| aws | 4.26.0 |
 
 ## Modules
 
 | Name | Source | Version |
 |------|--------|---------|
 | ecr\_alma\_webhook\_lambdas | ./modules/ecr | n/a |
+| ecr\_dss | ./modules/ecr | n/a |
+| ecr\_geoserver | ./modules/ecr | n/a |
+| ecr\_geosolr | ./modules/ecr | n/a |
+| ecr\_geoweb | ./modules/ecr | n/a |
 | ecr\_mario | ./modules/ecr | n/a |
 | ecr\_matomo | ./modules/ecr | n/a |
 | ecr\_oaiharvester | ./modules/ecr | n/a |
 | ecr\_ppod | ./modules/ecr | n/a |
+| ecr\_slingshot | ./modules/ecr | n/a |
 | ecr\_timdex\_lambdas | ./modules/ecr | n/a |
 | ecr\_timdex\_tim | ./modules/ecr | n/a |
 | ecr\_timdex\_transmogrifier | ./modules/ecr | n/a |
 | ecr\_wcd2reshare | ./modules/ecr | n/a |
+| ecr\_wiley | ./modules/ecr | n/a |
 
 ## Resources
 
@@ -90,6 +96,22 @@ A quick note for application developers and the integration of workflows to auto
 | alma\_webhook\_lambdas\_makefile | Full contents of the Makefile for the alma-webhook-lambdas repo (allows devs to push to Dev account only) |
 | alma\_webhook\_lambdas\_prod\_promote\_workflow | Full contents of the prod-promote.yml for the alma-webhook-lambdas repo |
 | alma\_webhook\_lambdas\_stage\_build\_workflow | Full contents of the stage-build.yml for the alma-webhook-lambdas repo |
+| dss\_fargate\_dev\_build\_workflow | Full contents of the dev-build.yml for the dss repo |
+| dss\_fargate\_makefile | Full contents of the Makefile for the dss repo (allows devs to push to Dev account only) |
+| dss\_fargate\_prod\_promote\_workflow | Full contents of the prod-promote.yml for the dss repo |
+| dss\_fargate\_stage\_build\_workflow | Full contents of the stage-build.yml for the dss repo |
+| geoserver\_fargate\_dev\_build\_workflow | Full contents of the dev-build.yml for the geoserver-deposits repo |
+| geoserver\_fargate\_makefile | Full contents of the Makefile for the geoserver-deposits repo (allows devs to push to Dev account only) |
+| geoserver\_fargate\_prod\_promote\_workflow | Full contents of the prod-promote.yml for the geoserver-deposits repo |
+| geoserver\_fargate\_stage\_build\_workflow | Full contents of the stage-build.yml for the geoserver-deposits repo |
+| geosolr\_fargate\_dev\_build\_workflow | Full contents of the dev-build.yml for the geosolr-deposits repo |
+| geosolr\_fargate\_makefile | Full contents of the Makefile for the geosolr-deposits repo (allows devs to push to Dev account only) |
+| geosolr\_fargate\_prod\_promote\_workflow | Full contents of the prod-promote.yml for the geosolr-deposits repo |
+| geosolr\_fargate\_stage\_build\_workflow | Full contents of the stage-build.yml for the geosolr-deposits repo |
+| geoweb\_fargate\_dev\_build\_workflow | Full contents of the dev-build.yml for the geoweb-deposits repo |
+| geoweb\_fargate\_makefile | Full contents of the Makefile for the geoweb-deposits repo (allows devs to push to Dev account only) |
+| geoweb\_fargate\_prod\_promote\_workflow | Full contents of the prod-promote.yml for the geoweb-deposits repo |
+| geoweb\_fargate\_stage\_build\_workflow | Full contents of the stage-build.yml for the geoweb-deposits repo |
 | mario\_dev\_build\_workflow | Full contents of the dev-build.yml for the mario repo |
 | mario\_makefile | Full contents of the Makefile for the mario repo (allows devs to push to Dev account only) |
 | mario\_prod\_promote\_workflow | Full contents of the prod-promote.yml for the mario repo |
@@ -106,6 +128,10 @@ A quick note for application developers and the integration of workflows to auto
 | ppod\_makefile | Full contents of the Makefile for the ppod repo (allows devs to push to Dev account only) |
 | ppod\_prod\_promote\_workflow | Full contents of the prod-promote.yml for the ppod repo |
 | ppod\_stage\_build\_workflow | Full contents of the stage-build.yml for the ppod repo |
+| slingshot\_fargate\_dev\_build\_workflow | Full contents of the dev-build.yml for the slingshot-deposits repo |
+| slingshot\_fargate\_makefile | Full contents of the Makefile for the slingshot-deposits repo (allows devs to push to Dev account only) |
+| slingshot\_fargate\_prod\_promote\_workflow | Full contents of the prod-promote.yml for the slingshot-deposits repo |
+| slingshot\_fargate\_stage\_build\_workflow | Full contents of the stage-build.yml for the slingshot-deposits repo |
 | tim\_dev\_build\_workflow | Full contents of the dev-build.yml for the timdex-index-manager repo |
 | tim\_makefile | Full contents of the Makefile for the timdex-index-manager repo (allows devs to push to Dev account only) |
 | tim\_prod\_promote\_workflow | Full contents of the prod-promote.yml for the timdex-index-manager repo |
@@ -122,4 +148,8 @@ A quick note for application developers and the integration of workflows to auto
 | wcd2reshare\_makefile | Full contents of the Makefile for the wcd2reshare repo (allows devs to push to Dev account only) |
 | wcd2reshare\_prod\_promote\_workflow | Full contents of the prod-promote.yml for the wcd2reshare repo |
 | wcd2reshare\_stage\_build\_workflow | Full contents of the stage-build.yml for the wcd2reshare repo |
+| wiley\_fargate\_dev\_build\_workflow | Full contents of the dev-build.yml for the wiley-deposits repo |
+| wiley\_fargate\_makefile | Full contents of the Makefile for the wiley-deposits repo (allows devs to push to Dev account only) |
+| wiley\_fargate\_prod\_promote\_workflow | Full contents of the prod-promote.yml for the wiley-deposits repo |
+| wiley\_fargate\_stage\_build\_workflow | Full contents of the stage-build.yml for the wiley-deposits repo |
 <!-- END_TF_DOCS -->

--- a/dss.tf
+++ b/dss.tf
@@ -1,0 +1,63 @@
+
+# dss containers
+# This is a standard ECR for an ECS with a Fargate launch type
+locals {
+  ecr_dss = "dspace-submission-service-${var.environment}"
+}
+module "ecr_dss" {
+  source            = "./modules/ecr"
+  repo_name         = "dspace-submission-service"
+  login_policy_arn  = aws_iam_policy.login.arn
+  oidc_arn          = data.aws_ssm_parameter.oidc_arn.value
+  environment       = var.environment
+  tfoutput_ssm_path = var.tfoutput_ssm_path
+  tags = {
+    app-repo = "dspace-submission-service"
+  }
+}
+
+## Outputs to Terraform Cloud for devs ##
+
+## For dss application repo and ECR repository
+# Outputs in dev
+output "dss_fargate_dev_build_workflow" {
+  value = var.environment == "prod" || var.environment == "stage" ? null : templatefile("${path.module}/files/fargate-dev-build.tpl", {
+    region = var.aws_region
+    role   = module.ecr_dss.gha_role
+    ecr    = module.ecr_dss.repository_name
+    }
+  )
+  description = "Full contents of the dev-build.yml for the dss repo"
+}
+output "dss_fargate_makefile" {
+  value = var.environment == "prod" || var.environment == "stage" ? null : templatefile("${path.module}/files/fargate-makefile.tpl", {
+    ecr_name = module.ecr_dss.repository_name
+    ecr_url  = module.ecr_dss.repository_url
+    }
+  )
+  description = "Full contents of the Makefile for the dss repo (allows devs to push to Dev account only)"
+}
+
+# Outputs in stage
+output "dss_fargate_stage_build_workflow" {
+  value = var.environment == "prod" || var.environment == "dev" ? null : templatefile("${path.module}/files/fargate-stage-build.tpl", {
+    region = var.aws_region
+    role   = module.ecr_dss.gha_role
+    ecr    = module.ecr_dss.repository_name
+    }
+  )
+  description = "Full contents of the stage-build.yml for the dss repo"
+}
+
+# Outputs after promotion to prod
+output "dss_fargate_prod_promote_workflow" {
+  value = var.environment == "stage" || var.environment == "dev" ? null : templatefile("${path.module}/files/fargate-prod-promote.tpl", {
+    region     = var.aws_region
+    role_stage = "${module.ecr_dss.repo_name}-gha-stage"
+    role_prod  = "${module.ecr_dss.repo_name}-gha-prod"
+    ecr_stage  = "${module.ecr_dss.repo_name}-stage"
+    ecr_prod   = "${module.ecr_dss.repo_name}-prod"
+    }
+  )
+  description = "Full contents of the prod-promote.yml for the dss repo"
+}

--- a/gis_ecrs.tf
+++ b/gis_ecrs.tf
@@ -1,0 +1,238 @@
+## Container repositories for the GIS stack
+# Geoweb containers - a DLS-managed Ruby-on-Rails application that is dockerized
+# This is a standard ECR for an ECS with a Fargate launch type
+module "ecr_geoweb" {
+  source            = "./modules/ecr"
+  repo_name         = "geoweb"
+  login_policy_arn  = aws_iam_policy.login.arn
+  oidc_arn          = data.aws_ssm_parameter.oidc_arn.value
+  environment       = var.environment
+  tfoutput_ssm_path = var.tfoutput_ssm_path
+  tags = {
+    app-repo   = "geoweb"
+    project-id = "gis-services"
+  }
+}
+
+# GeoServer containers - a modification of the official GeoServer Docker container
+# This is a standard ECR for an ECS with a Fargate launch type
+module "ecr_geoserver" {
+  source            = "./modules/ecr"
+  repo_name         = "docker-geoserver"
+  login_policy_arn  = aws_iam_policy.login.arn
+  oidc_arn          = data.aws_ssm_parameter.oidc_arn.value
+  environment       = var.environment
+  tfoutput_ssm_path = var.tfoutput_ssm_path
+  tags = {
+    app-repo   = "docker-geoserver"
+    project-id = "gis-services"
+  }
+}
+
+# GeoSolr containers - a modification of the official Solr Docker container
+# This is a standard ECR for an ECS with a Fargate launch type
+module "ecr_geosolr" {
+  source            = "./modules/ecr"
+  repo_name         = "docker-geosolr"
+  login_policy_arn  = aws_iam_policy.login.arn
+  oidc_arn          = data.aws_ssm_parameter.oidc_arn.value
+  environment       = var.environment
+  tfoutput_ssm_path = var.tfoutput_ssm_path
+  tags = {
+    app-repo   = "docker-geosolr"
+    project-id = "gis-services"
+  }
+}
+
+# Slingshot containers - a DLS-managed Python application that is dockerized
+# This is a standard ECR for an ECS with a Fargate launch type
+module "ecr_slingshot" {
+  source            = "./modules/ecr"
+  repo_name         = "slingshot"
+  login_policy_arn  = aws_iam_policy.login.arn
+  oidc_arn          = data.aws_ssm_parameter.oidc_arn.value
+  environment       = var.environment
+  tfoutput_ssm_path = var.tfoutput_ssm_path
+  tags = {
+    app-repo   = "slingshot"
+    project-id = "gis-services"
+  }
+}
+
+## Outputs to Terraform Cloud for devs ##
+
+## For geoweb application repo and ECR repository
+# Outputs in dev
+output "geoweb_fargate_dev_build_workflow" {
+  value = var.environment == "prod" || var.environment == "stage" ? null : templatefile("${path.module}/files/fargate-dev-build.tpl", {
+    region = var.aws_region
+    role   = module.ecr_geoweb.gha_role
+    ecr    = module.ecr_geoweb.repository_name
+    }
+  )
+  description = "Full contents of the dev-build.yml for the geoweb-deposits repo"
+}
+output "geoweb_fargate_makefile" {
+  value = var.environment == "prod" || var.environment == "stage" ? null : templatefile("${path.module}/files/fargate-makefile.tpl", {
+    ecr_name = module.ecr_geoweb.repository_name
+    ecr_url  = module.ecr_geoweb.repository_url
+    }
+  )
+  description = "Full contents of the Makefile for the geoweb-deposits repo (allows devs to push to Dev account only)"
+}
+
+# Outputs in stage
+output "geoweb_fargate_stage_build_workflow" {
+  value = var.environment == "prod" || var.environment == "dev" ? null : templatefile("${path.module}/files/fargate-stage-build.tpl", {
+    region = var.aws_region
+    role   = module.ecr_geoweb.gha_role
+    ecr    = module.ecr_geoweb.repository_name
+    }
+  )
+  description = "Full contents of the stage-build.yml for the geoweb-deposits repo"
+}
+
+# Outputs after promotion to prod
+output "geoweb_fargate_prod_promote_workflow" {
+  value = var.environment == "stage" || var.environment == "dev" ? null : templatefile("${path.module}/files/fargate-prod-promote.tpl", {
+    region     = var.aws_region
+    role_stage = "${module.ecr_geoweb.repo_name}-gha-stage"
+    role_prod  = "${module.ecr_geoweb.repo_name}-gha-prod"
+    ecr_stage  = "${module.ecr_geoweb.repo_name}-stage"
+    ecr_prod   = "${module.ecr_geoweb.repo_name}-prod"
+    }
+  )
+  description = "Full contents of the prod-promote.yml for the geoweb-deposits repo"
+}
+
+## For geoserver application repo and ECR repository
+# Outputs in dev
+output "geoserver_fargate_dev_build_workflow" {
+  value = var.environment == "prod" || var.environment == "stage" ? null : templatefile("${path.module}/files/fargate-dev-build.tpl", {
+    region = var.aws_region
+    role   = module.ecr_geoserver.gha_role
+    ecr    = module.ecr_geoserver.repository_name
+    }
+  )
+  description = "Full contents of the dev-build.yml for the geoserver-deposits repo"
+}
+output "geoserver_fargate_makefile" {
+  value = var.environment == "prod" || var.environment == "stage" ? null : templatefile("${path.module}/files/fargate-makefile.tpl", {
+    ecr_name = module.ecr_geoserver.repository_name
+    ecr_url  = module.ecr_geoserver.repository_url
+    }
+  )
+  description = "Full contents of the Makefile for the geoserver-deposits repo (allows devs to push to Dev account only)"
+}
+
+# Outputs in stage
+output "geoserver_fargate_stage_build_workflow" {
+  value = var.environment == "prod" || var.environment == "dev" ? null : templatefile("${path.module}/files/fargate-stage-build.tpl", {
+    region = var.aws_region
+    role   = module.ecr_geoserver.gha_role
+    ecr    = module.ecr_geoserver.repository_name
+    }
+  )
+  description = "Full contents of the stage-build.yml for the geoserver-deposits repo"
+}
+
+# Outputs after promotion to prod
+output "geoserver_fargate_prod_promote_workflow" {
+  value = var.environment == "stage" || var.environment == "dev" ? null : templatefile("${path.module}/files/fargate-prod-promote.tpl", {
+    region     = var.aws_region
+    role_stage = "${module.ecr_geoserver.repo_name}-gha-stage"
+    role_prod  = "${module.ecr_geoserver.repo_name}-gha-prod"
+    ecr_stage  = "${module.ecr_geoserver.repo_name}-stage"
+    ecr_prod   = "${module.ecr_geoserver.repo_name}-prod"
+    }
+  )
+  description = "Full contents of the prod-promote.yml for the geoserver-deposits repo"
+}
+
+## For geosolr application repo and ECR repository
+# Outputs in dev
+output "geosolr_fargate_dev_build_workflow" {
+  value = var.environment == "prod" || var.environment == "stage" ? null : templatefile("${path.module}/files/fargate-dev-build.tpl", {
+    region = var.aws_region
+    role   = module.ecr_geosolr.gha_role
+    ecr    = module.ecr_geosolr.repository_name
+    }
+  )
+  description = "Full contents of the dev-build.yml for the geosolr-deposits repo"
+}
+output "geosolr_fargate_makefile" {
+  value = var.environment == "prod" || var.environment == "stage" ? null : templatefile("${path.module}/files/fargate-makefile.tpl", {
+    ecr_name = module.ecr_geosolr.repository_name
+    ecr_url  = module.ecr_geosolr.repository_url
+    }
+  )
+  description = "Full contents of the Makefile for the geosolr-deposits repo (allows devs to push to Dev account only)"
+}
+
+# Outputs in stage
+output "geosolr_fargate_stage_build_workflow" {
+  value = var.environment == "prod" || var.environment == "dev" ? null : templatefile("${path.module}/files/fargate-stage-build.tpl", {
+    region = var.aws_region
+    role   = module.ecr_geosolr.gha_role
+    ecr    = module.ecr_geosolr.repository_name
+    }
+  )
+  description = "Full contents of the stage-build.yml for the geosolr-deposits repo"
+}
+
+# Outputs after promotion to prod
+output "geosolr_fargate_prod_promote_workflow" {
+  value = var.environment == "stage" || var.environment == "dev" ? null : templatefile("${path.module}/files/fargate-prod-promote.tpl", {
+    region     = var.aws_region
+    role_stage = "${module.ecr_geosolr.repo_name}-gha-stage"
+    role_prod  = "${module.ecr_geosolr.repo_name}-gha-prod"
+    ecr_stage  = "${module.ecr_geosolr.repo_name}-stage"
+    ecr_prod   = "${module.ecr_geosolr.repo_name}-prod"
+    }
+  )
+  description = "Full contents of the prod-promote.yml for the geosolr-deposits repo"
+}
+
+## For slingshot application repo and ECR repository
+# Outputs in dev
+output "slingshot_fargate_dev_build_workflow" {
+  value = var.environment == "prod" || var.environment == "stage" ? null : templatefile("${path.module}/files/fargate-dev-build.tpl", {
+    region = var.aws_region
+    role   = module.ecr_slingshot.gha_role
+    ecr    = module.ecr_slingshot.repository_name
+    }
+  )
+  description = "Full contents of the dev-build.yml for the slingshot-deposits repo"
+}
+output "slingshot_fargate_makefile" {
+  value = var.environment == "prod" || var.environment == "stage" ? null : templatefile("${path.module}/files/fargate-makefile.tpl", {
+    ecr_name = module.ecr_slingshot.repository_name
+    ecr_url  = module.ecr_slingshot.repository_url
+    }
+  )
+  description = "Full contents of the Makefile for the slingshot-deposits repo (allows devs to push to Dev account only)"
+}
+
+# Outputs in stage
+output "slingshot_fargate_stage_build_workflow" {
+  value = var.environment == "prod" || var.environment == "dev" ? null : templatefile("${path.module}/files/fargate-stage-build.tpl", {
+    region = var.aws_region
+    role   = module.ecr_slingshot.gha_role
+    ecr    = module.ecr_slingshot.repository_name
+    }
+  )
+  description = "Full contents of the stage-build.yml for the slingshot-deposits repo"
+}
+
+# Outputs after promotion to prod
+output "slingshot_fargate_prod_promote_workflow" {
+  value = var.environment == "stage" || var.environment == "dev" ? null : templatefile("${path.module}/files/fargate-prod-promote.tpl", {
+    region     = var.aws_region
+    role_stage = "${module.ecr_slingshot.repo_name}-gha-stage"
+    role_prod  = "${module.ecr_slingshot.repo_name}-gha-prod"
+    ecr_stage  = "${module.ecr_slingshot.repo_name}-stage"
+    ecr_prod   = "${module.ecr_slingshot.repo_name}-prod"
+    }
+  )
+  description = "Full contents of the prod-promote.yml for the slingshot-deposits repo"
+}

--- a/matomo_ecr.tf
+++ b/matomo_ecr.tf
@@ -6,13 +6,13 @@ locals {
 }
 module "ecr_matomo" {
   source            = "./modules/ecr"
-  repo_name         = "matomo"
+  repo_name         = "docker-matomo"
   login_policy_arn  = aws_iam_policy.login.arn
   oidc_arn          = data.aws_ssm_parameter.oidc_arn.value
   environment       = var.environment
   tfoutput_ssm_path = var.tfoutput_ssm_path
   tags = {
-    app-repo = "matomo"
+    app-repo = "docker-matomo"
   }
 }
 

--- a/modules/README.md
+++ b/modules/README.md
@@ -8,14 +8,14 @@ The outputs from the module are stored in Parameter Store in the standard parame
 
 | Name | Version |
 |------|---------|
-| terraform | ~> 1.1 |
-| aws | ~> 3.0 |
+| terraform | ~> 1.2 |
+| aws | ~> 4.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| aws | ~> 3.0 |
+| aws | ~> 4.0 |
 
 ## Modules
 
@@ -31,6 +31,7 @@ No modules.
 | [aws_iam_role.gha_this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role_policy_attachment.gha_ecr_login](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.gha_ecr_rw](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_ssm_parameter.ecr_repository_name](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssm_parameter) | resource |
 | [aws_ssm_parameter.ecr_repository_url](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssm_parameter) | resource |
 | [aws_ssm_parameter.gha_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssm_parameter) | resource |
 | [aws_iam_policy_document.gh_trust](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
@@ -40,7 +41,7 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| environment | The environement (dev, stage, or prod) | `string` | n/a | yes |
+| environment | The environment (dev, stage, or prod) | `string` | n/a | yes |
 | gh\_organization | The name of the GitHub Organization. | `string` | `"MITLibraries"` | no |
 | login\_policy\_arn | The ARN of the shared ECR login policy | `string` | n/a | yes |
 | oidc\_arn | The ARN of the OIDC profile | `string` | n/a | yes |
@@ -50,4 +51,9 @@ No modules.
 
 ## Outputs
 
-No outputs.
+| Name | Description |
+|------|-------------|
+| gha\_role | Github action role used to update the ECR repository |
+| repo\_name | The repo\_name that was passed in to the module for naming purposes |
+| repository\_name | The name of the ECR repository |
+| repository\_url | The URL of the ECR repository |

--- a/modules/ecr/variables.tf
+++ b/modules/ecr/variables.tf
@@ -17,7 +17,7 @@ variable "gh_organization" {
 ## Shared information passed from main code (since modules do not inherit variables/values from the root)
 # The environment (pulled by the root module from TfC variables)
 variable "environment" {
-  description = "The environement (dev, stage, or prod)"
+  description = "The environment (dev, stage, or prod)"
   type        = string
 }
 

--- a/modules/ecr/versions.tf
+++ b/modules/ecr/versions.tf
@@ -3,12 +3,12 @@
 # Providers themselves are set in the `providers.tf` file.
 
 terraform {
-  required_version = "~> 1.1"
+  required_version = "~> 1.2"
 
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 3.0"
+      version = "~> 4.0"
     }
   }
 }

--- a/versions.tf
+++ b/versions.tf
@@ -3,12 +3,12 @@
 # Providers themselves are set in the `providers.tf` file.
 
 terraform {
-  required_version = "~> 1.1"
+  required_version = "~> 1.2"
 
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 3.0"
+      version = "~> 4.0"
     }
   }
 }

--- a/wiley.tf
+++ b/wiley.tf
@@ -1,0 +1,63 @@
+
+# wiley containers
+# This is a standard ECR for an ECS with a Fargate launch type
+locals {
+  ecr_wiley = "wiley-${var.environment}"
+}
+module "ecr_wiley" {
+  source            = "./modules/ecr"
+  repo_name         = "wiley-deposits"
+  login_policy_arn  = aws_iam_policy.login.arn
+  oidc_arn          = data.aws_ssm_parameter.oidc_arn.value
+  environment       = var.environment
+  tfoutput_ssm_path = var.tfoutput_ssm_path
+  tags = {
+    app-repo = "wiley-deposits"
+  }
+}
+
+## Outputs to Terraform Cloud for devs ##
+
+## For wiley application repo and ECR repository
+# Outputs in dev
+output "wiley_fargate_dev_build_workflow" {
+  value = var.environment == "prod" || var.environment == "stage" ? null : templatefile("${path.module}/files/fargate-dev-build.tpl", {
+    region = var.aws_region
+    role   = module.ecr_wiley.gha_role
+    ecr    = module.ecr_wiley.repository_name
+    }
+  )
+  description = "Full contents of the dev-build.yml for the wiley-deposits repo"
+}
+output "wiley_fargate_makefile" {
+  value = var.environment == "prod" || var.environment == "stage" ? null : templatefile("${path.module}/files/fargate-makefile.tpl", {
+    ecr_name = module.ecr_wiley.repository_name
+    ecr_url  = module.ecr_wiley.repository_url
+    }
+  )
+  description = "Full contents of the Makefile for the wiley-deposits repo (allows devs to push to Dev account only)"
+}
+
+# Outputs in stage
+output "wiley_fargate_stage_build_workflow" {
+  value = var.environment == "prod" || var.environment == "dev" ? null : templatefile("${path.module}/files/fargate-stage-build.tpl", {
+    region = var.aws_region
+    role   = module.ecr_wiley.gha_role
+    ecr    = module.ecr_wiley.repository_name
+    }
+  )
+  description = "Full contents of the stage-build.yml for the wiley-deposits repo"
+}
+
+# Outputs after promotion to prod
+output "wiley_fargate_prod_promote_workflow" {
+  value = var.environment == "stage" || var.environment == "dev" ? null : templatefile("${path.module}/files/fargate-prod-promote.tpl", {
+    region     = var.aws_region
+    role_stage = "${module.ecr_wiley.repo_name}-gha-stage"
+    role_prod  = "${module.ecr_wiley.repo_name}-gha-prod"
+    ecr_stage  = "${module.ecr_wiley.repo_name}-stage"
+    ecr_prod   = "${module.ecr_wiley.repo_name}-prod"
+    }
+  )
+  description = "Full contents of the prod-promote.yml for the wiley-deposits repo"
+}


### PR DESCRIPTION
#### Developer Checklist

- [X] The README contains any additional info needed outside of the terraform docs generated
- [X] Any special variables have values configured in AWS SSM
- [X] Stakeholder approval has been confirmed (or is not needed)

#### What does this PR do?

* Add the GIS-related ECR repositories to Prod-Workloads
* Add Wiley and DSS ECR repositories to Prod-Workloads
* Update the name of the Matomo-related ECR repository to match the corrected name of the GitHub app repository
* Closes Issue #17 

#### Helpful background context

This gets our ECR repo names, OIDC connections for GHA automated workflows, and our GitHub application repositories aligned, especially for application repositories that are essentially just modified Dockerfiles for 3rd party Docker images.

**Note**: The existing ECR repository for Matomo in Prod-Workloads is empty, so there are no issues deploying this with Terraform.

#### What are the relevant tickets?

[IN-487](https://mitlibraries.atlassian.net/browse/IN-487)
[IN-496](https://mitlibraries.atlassian.net/browse/IN-496)

#### Requires Database Migrations?

NO

#### Includes new or updated dependencies?

YES: The Matomo-related ECS services and tasks will need to be updated to pull from the corrected ECR. The docker-matomo repository will need to get an update Makefile and updated GHA workflows from the outputs of this deploy in Terraform Cloud.

