### PR TITLE
Update Outputs for Shared Workflows

### DIFF
--- a/.terraform.lock.hcl
+++ b/.terraform.lock.hcl
@@ -5,6 +5,7 @@ provider "registry.terraform.io/hashicorp/aws" {
   version     = "4.26.0"
   constraints = "~> 4.0"
   hashes = [
+    "h1:9OhWumg7aXjhiZKQ33QLlAsbYtE0hJ920BvLFr9jxMA=",
     "h1:q0QTY+O5L//LGGkmlUlEvTLnNSsdV91Tqm7BFqwpSII=",
     "zh:0579b105ae471894846fbd740bc9f10b2bd8a48860d8e640b4a9b53fb7d63ffe",
     "zh:0ce445cfbffb6c0eee9e0e2a95850b5749d56aa8211b95a686c24dc2847a36ea",

--- a/README.md
+++ b/README.md
@@ -117,10 +117,10 @@ then replace all the ssm parameter references for `oidc_arn` with `aws_iam_openi
 | alma\_webhook\_lambdas\_makefile | Full contents of the Makefile for the alma-webhook-lambdas repo (allows devs to push to Dev account only) |
 | alma\_webhook\_lambdas\_prod\_promote\_workflow | Full contents of the prod-promote.yml for the alma-webhook-lambdas repo |
 | alma\_webhook\_lambdas\_stage\_build\_workflow | Full contents of the stage-build.yml for the alma-webhook-lambdas repo |
-| carbon\_fargate\_dev\_build\_workflow | Full contents of the dev-build.yml for the carbon repo |
-| carbon\_fargate\_makefile | Full contents of the Makefile for the carbon repo (allows devs to push to Dev account only) |
-| carbon\_fargate\_prod\_promote\_workflow | Full contents of the prod-promote.yml for the carbon repo |
-| carbon\_fargate\_stage\_build\_workflow | Full contents of the stage-build.yml for the carbon repo |
+| carbon\_dev\_build\_workflow | Full contents of the dev-build.yml for the carbon repo |
+| carbon\_makefile | Full contents of the Makefile for the carbon repo (allows devs to push to Dev account only) |
+| carbon\_prod\_promote\_workflow | Full contents of the prod-promote.yml for the carbon repo |
+| carbon\_stage\_build\_workflow | Full contents of the stage-build.yml for the carbon repo |
 | dss\_fargate\_dev\_build\_workflow | Full contents of the dev-build.yml for the dss repo |
 | dss\_fargate\_makefile | Full contents of the Makefile for the dss repo (allows devs to push to Dev account only) |
 | dss\_fargate\_prod\_promote\_workflow | Full contents of the prod-promote.yml for the dss repo |

--- a/carbon_ecr.tf
+++ b/carbon_ecr.tf
@@ -16,47 +16,52 @@ module "ecr_carbon" {
   }
 }
 
+
 ## Outputs to Terraform Cloud for devs ##
 
 ## For carbon application repo and ECR repository
 # Outputs in dev
-output "carbon_fargate_dev_build_workflow" {
-  value = var.environment == "prod" || var.environment == "stage" ? null : templatefile("${path.module}/files/fargate-dev-build.tpl", {
-    region = var.aws_region
-    role   = module.ecr_carbon.gha_role
-    ecr    = module.ecr_carbon.repository_name
+output "carbon_dev_build_workflow" {
+  value = var.environment == "prod" || var.environment == "stage" ? null : templatefile("${path.module}/files/dev-build.tpl", {
+    region   = var.aws_region
+    role     = module.ecr_carbon.gha_role
+    ecr      = module.ecr_carbon.repository_name
+    function = ""
     }
   )
   description = "Full contents of the dev-build.yml for the carbon repo"
 }
-output "carbon_fargate_makefile" {
-  value = var.environment == "prod" || var.environment == "stage" ? null : templatefile("${path.module}/files/fargate-makefile.tpl", {
+output "carbon_makefile" {
+  value = var.environment == "prod" || var.environment == "stage" ? null : templatefile("${path.module}/files/makefile.tpl", {
     ecr_name = module.ecr_carbon.repository_name
     ecr_url  = module.ecr_carbon.repository_url
+    function = ""
     }
   )
   description = "Full contents of the Makefile for the carbon repo (allows devs to push to Dev account only)"
 }
 
 # Outputs in stage
-output "carbon_fargate_stage_build_workflow" {
-  value = var.environment == "prod" || var.environment == "dev" ? null : templatefile("${path.module}/files/fargate-stage-build.tpl", {
-    region = var.aws_region
-    role   = module.ecr_carbon.gha_role
-    ecr    = module.ecr_carbon.repository_name
+output "carbon_stage_build_workflow" {
+  value = var.environment == "prod" || var.environment == "dev" ? null : templatefile("${path.module}/files/stage-build.tpl", {
+    region   = var.aws_region
+    role     = module.ecr_carbon.gha_role
+    ecr      = module.ecr_carbon.repository_name
+    function = null
     }
   )
   description = "Full contents of the stage-build.yml for the carbon repo"
 }
 
 # Outputs after promotion to prod
-output "carbon_fargate_prod_promote_workflow" {
-  value = var.environment == "stage" || var.environment == "dev" ? null : templatefile("${path.module}/files/fargate-prod-promote.tpl", {
+output "carbon_prod_promote_workflow" {
+  value = var.environment == "stage" || var.environment == "dev" ? null : templatefile("${path.module}/files/prod-promote.tpl", {
     region     = var.aws_region
     role_stage = "${module.ecr_carbon.repo_name}-gha-stage"
     role_prod  = "${module.ecr_carbon.repo_name}-gha-prod"
     ecr_stage  = "${module.ecr_carbon.repo_name}-stage"
     ecr_prod   = "${module.ecr_carbon.repo_name}-prod"
+    function   = null
     }
   )
   description = "Full contents of the prod-promote.yml for the carbon repo"

--- a/files/dev-build.tpl
+++ b/files/dev-build.tpl
@@ -1,0 +1,24 @@
+### This is the Terraform-generated dev-build.yml workflow for the ${ecr} app repository ###
+### If this is a Lambda repo, uncomment the FUNCTION line at the end of the document     ###
+### If the container requires any additional pre-build commands, uncomment and edit      ###
+### the PREBUILD line at the end of the document.                                        ###
+name: Dev Container Build and Deploy
+on:
+  workflow_dispatch:
+  pull_request:
+    branches:
+      - main
+    paths-ignore:
+      - '.github/**'
+
+jobs:
+  deploy:
+    name: Dev Container Deploy
+    uses: mitlibraries/.github/.github/workflows/ecr-shared-deploy-dev.yml@main
+    secrets: inherit
+    with:
+      AWS_REGION: "${region}"
+      GHA_ROLE: "${role}"
+      ECR: "${ecr}"
+      # FUNCTION: "${function}"
+      # PREBUILD: 

--- a/files/makefile.tpl
+++ b/files/makefile.tpl
@@ -1,0 +1,44 @@
+### This is the Terraform-generated header for ${ecr_name}. If  ###
+###   this is a Lambda repo, uncomment the FUNCTION line below  ###
+###   and review the other commented lines in the document.     ###
+ECR_NAME_DEV:=${ecr_name}
+ECR_URL_DEV:=${ecr_url}
+# FUNCTION_DEV:=${function}
+### End of Terraform-generated header                            ###
+
+### Terraform-generated Developer Deploy Commands for Dev environment ###
+dist-dev: ## Build docker container (intended for developer-based manual build)
+	docker build --platform linux/amd64 \
+	    -t $(ECR_URL_DEV):latest \
+		-t $(ECR_URL_DEV):`git describe --always` \
+		-t $(ECR_NAME_DEV):latest .
+
+publish-dev: dist-dev ## Build, tag and push (intended for developer-based manual publish)
+	docker login -u AWS -p $$(aws ecr get-login-password --region us-east-1) $(ECR_URL_DEV)
+	docker push $(ECR_URL_DEV):latest
+	docker push $(ECR_URL_DEV):`git describe --always`
+
+### If this is a Lambda repo, uncomment the two lines below     ###
+# update-lambda-dev: ## Updates the lambda with whatever is the most recent image in the ecr (intended for developer-based manual update)
+#	aws lambda update-function-code --function-name $(FUNCTION_DEV) --image-uri $(ECR_URL_DEV):latest
+
+
+### Terraform-generated manual shortcuts for deploying to Stage. This requires  ###
+###   that ECR_NAME_STAGE, ECR_URL_STAGE, and FUNCTION_STAGE environment        ###
+###   variables are set locally by the developer and that the developer has     ###
+###   authenticated to the correct AWS Account. The values for the environment  ###
+###   variables can be found in the stage_build.yml caller workflow.            ###
+dist-stage: ## Only use in an emergency
+	docker build --platform linux/amd64 \
+	    -t $(ECR_URL_STAGE):latest \
+		-t $(ECR_URL_STAGE):`git describe --always` \
+		-t $(ECR_NAME_STAGE):latest .
+
+publish-stage: ## Only use in an emergency
+	docker login -u AWS -p $$(aws ecr get-login-password --region us-east-1) $(ECR_URL_STAGE)
+	docker push $(ECR_URL_STAGE):latest
+	docker push $(ECR_URL_STAGE):`git describe --always`
+
+### If this is a Lambda repo, uncomment the two lines below     ###
+# update-lambda-stage: ## Updates the lambda with whatever is the most recent image in the ecr (intended for developer-based manual update)
+#	aws lambda update-function-code --function-name $(FUNCTION_STAGE) --image-uri $(ECR_URL_STAGE):latest

--- a/files/prod-promote.tpl
+++ b/files/prod-promote.tpl
@@ -1,0 +1,21 @@
+### This is the Terraform-generated prod-promote.yml workflow for the ${ecr} app repository. ###
+### If this is a Lambda repo, uncomment the FUNCTION line at the end of the document         ###
+name: Prod Container Promote
+on:
+  workflow_dispatch:
+  release:
+    types: [published]
+
+jobs:
+  deploy:
+    name: Prod Container Promote
+    uses: mitlibraries/.github/.github/workflows/ecr-shared-promote-prod.yml@main
+    secrets: inherit
+    with:
+      AWS_REGION: "${region}"
+      GHA_ROLE_STAGE: ${role_stage}
+      GHA_ROLE_PROD: ${role_prod}
+      ECR_STAGE: "${ecr_stage}"
+      ECR_PROD: "${ecr_prod}"
+      # FUNCTION: "${function}"
+ 

--- a/files/stage-build.tpl
+++ b/files/stage-build.tpl
@@ -1,0 +1,24 @@
+### This is the Terraform-generated dev-build.yml workflow for the ${ecr} app repository ###
+### If this is a Lambda repo, uncomment the FUNCTION line at the end of the document     ###
+### If the container requires any additional pre-build commands, uncomment and edit      ###
+### the PREBUILD line at the end of the document.                                        ###
+name: Stage Container Build and Deploy
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+    paths-ignore:
+      - '.github/**'
+
+jobs:
+  deploy:
+    name: Stage Container Deploy
+    uses: mitlibraries/.github/.github/workflows/ecr-shared-deploy-stage.yml@main
+    secrets: inherit
+    with:
+      AWS_REGION: "${region}"
+      GHA_ROLE: "${role}"
+      ECR: "${ecr}"
+      # FUNCTION: "${function}"
+      # PREBUILD: 


### PR DESCRIPTION
### Developer Checklist

- [X] The README contains any additional info needed outside of the terraform docs generated
- [X] Any special variables have values configured in AWS SSM
- [X] Stakeholder approval has been confirmed (or is not needed)

### What does this PR do?

* Create three new template files for dev-build, stage-build, and prod-promote caller workflow outputs
* Create one new template file for the Makefile output
* Update the output resources for just the carbon ECR to use the new template files

In the near future, we will need to update the Terraform Outputs to use the new templates and eventually remove the outdated templates once we have upgraded across our multiple repositories.

### Helpful background context

The Carbon app introduces a few changes to our automated build process. There are changes in the shared workflows in the MIT Libraries .giuthub repository that reflect the automated build changes necessary for carbon. The changes in this repo update the Terraform Outputs to match the new input requirements of the shared workflows.

As part of addressing the needs of the Carbon app, it made sense to consolidate the shared workflows by using a few conditional steps. The changes here continue that idea of consolidation with conditional text.

Side effects of this change:
None. In fact, the only changes are changes to output values. This will not make any changes to the infrastructure in AWS.

### What are the relevant tickets?

* https://mitlibraries.atlassian.net/browse/IN-568
* https://mitlibraries.atlassian.net/browse/IN-615

### Requires Database Migrations?

NO

### Includes new or updated dependencies?

NO
