### PR TITLE
Fix prod-promote typo

### DIFF
--- a/files/prod-promote.tpl
+++ b/files/prod-promote.tpl
@@ -1,5 +1,5 @@
-### This is the Terraform-generated prod-promote.yml workflow for the ${ecr} app repository. ###
-### If this is a Lambda repo, uncomment the FUNCTION line at the end of the document         ###
+### This is the Terraform-generated prod-promote.yml workflow for the ${ecr_prod} repository. ###
+### If this is a Lambda repo, uncomment the FUNCTION line at the end of the document.         ###
 name: Prod Container Promote
 on:
   workflow_dispatch:


### PR DESCRIPTION
### Developer Checklist

- [X] The README contains any additional info needed outside of the terraform docs generated
- [X] Any special variables have values configured in AWS SSM
- [X] Stakeholder approval has been confirmed (or is not needed)

### What does this PR do?

* Change the ${ecr} reference in prod-promote.tpl to ${ecr_prod}

### Helpful background context

When attempting to merge this to the `main` branch, the `terraform plan` failed because of a typo in the prod-promote.tpl file. With our 3-branch workflow, this change needs to be made back in the `dev` branch and then rolled forward again. This will not show any changes in Dev1 or in Stage-Workloads, but will only affect a Terraform output in Prod-Workloads.

### What are the relevant tickets?

* https://mitlibraries.atlassian.net/browse/IN-568

#### Requires Database Migrations?

NO

#### Includes new or updated dependencies?

NO
