### PR TITLE
Dev into stage, remove mario ECR #34

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,6 @@ then replace all the ssm parameter references for `oidc_arn` with `aws_iam_openi
 | ecr\_geoserver | ./modules/ecr | n/a |
 | ecr\_geosolr | ./modules/ecr | n/a |
 | ecr\_geoweb | ./modules/ecr | n/a |
-| ecr\_mario | ./modules/ecr | n/a |
 | ecr\_matomo | ./modules/ecr | n/a |
 | ecr\_oaiharvester | ./modules/ecr | n/a |
 | ecr\_patronload | ./modules/ecr | n/a |
@@ -147,10 +146,6 @@ then replace all the ssm parameter references for `oidc_arn` with `aws_iam_openi
 | geoweb\_fargate\_makefile | Full contents of the Makefile for the geoweb-deposits repo (allows devs to push to Dev account only) |
 | geoweb\_fargate\_prod\_promote\_workflow | Full contents of the prod-promote.yml for the geoweb-deposits repo |
 | geoweb\_fargate\_stage\_build\_workflow | Full contents of the stage-build.yml for the geoweb-deposits repo |
-| mario\_dev\_build\_workflow | Full contents of the dev-build.yml for the mario repo |
-| mario\_makefile | Full contents of the Makefile for the mario repo (allows devs to push to Dev account only) |
-| mario\_prod\_promote\_workflow | Full contents of the prod-promote.yml for the mario repo |
-| mario\_stage\_build\_workflow | Full contents of the stage-build.yml for the mario repo |
 | matomo\_fargate\_dev\_build\_workflow | Full contents of the dev-build.yml for the matomo repo |
 | matomo\_fargate\_makefile | Full contents of the Makefile for the matomo repo (allows devs to push to Dev account only) |
 | matomo\_fargate\_prod\_promote\_workflow | Full contents of the prod-promote.yml for the matomo repo |

--- a/timdex_ecrs.tf
+++ b/timdex_ecrs.tf
@@ -2,67 +2,6 @@
 ### Timdex related ECR's
 ### 
 
-## mario
-# the mario ECR
-module "ecr_mario" {
-  source            = "./modules/ecr"
-  repo_name         = "mario"
-  login_policy_arn  = aws_iam_policy.login.arn
-  oidc_arn          = data.aws_ssm_parameter.oidc_arn.value
-  environment       = var.environment
-  tfoutput_ssm_path = var.tfoutput_ssm_path
-  tags = {
-    app-repo = "timdex-infrastructure-mario"
-  }
-}
-
-# Outputs in dev
-output "mario_dev_build_workflow" {
-  value = var.environment == "prod" || var.environment == "stage" ? null : templatefile("${path.module}/files/dev-build.tpl", {
-    region   = var.aws_region
-    role     = module.ecr_mario.gha_role
-    ecr      = module.ecr_mario.repository_name
-    function = ""
-    }
-  )
-  description = "Full contents of the dev-build.yml for the mario repo"
-}
-output "mario_makefile" {
-  value = var.environment == "prod" || var.environment == "stage" ? null : templatefile("${path.module}/files/makefile.tpl", {
-    ecr_name = module.ecr_mario.repository_name
-    ecr_url  = module.ecr_mario.repository_url
-    function = ""
-    }
-  )
-  description = "Full contents of the Makefile for the mario repo (allows devs to push to Dev account only)"
-}
-
-# Outputs in stage
-output "mario_stage_build_workflow" {
-  value = var.environment == "prod" || var.environment == "dev" ? null : templatefile("${path.module}/files/stage-build.tpl", {
-    region   = var.aws_region
-    role     = module.ecr_mario.gha_role
-    ecr      = module.ecr_mario.repository_name
-    function = ""
-    }
-  )
-  description = "Full contents of the stage-build.yml for the mario repo"
-}
-
-# Outputs after promotion to prod
-output "mario_prod_promote_workflow" {
-  value = var.environment == "stage" || var.environment == "dev" ? null : templatefile("${path.module}/files/prod-promote.tpl", {
-    region     = var.aws_region
-    role_stage = "${module.ecr_mario.repo_name}-gha-stage"
-    role_prod  = "${module.ecr_mario.repo_name}-gha-prod"
-    ecr_stage  = "${module.ecr_mario.repo_name}-stage"
-    ecr_prod   = "${module.ecr_mario.repo_name}-prod"
-    function   = ""
-    }
-  )
-  description = "Full contents of the prod-promote.yml for the mario repo"
-}
-
 ## oaiharvester
 # oaiharvester ECR repo
 module "ecr_oaiharvester" {


### PR DESCRIPTION
#### Developer Checklist

- [X] The README contains any additional info needed outside of the terraform docs generated
- [X] Any special variables have values configured in AWS SSM
- [X] Stakeholder approval has been confirmed (or is not needed)

#### What does this PR do?
Removes mario ECR and related permissions used to populate the ECR from github
Mario is no longer needed, it has been replaced by TIM

#### Helpful background context

Before executing this in stage, i'll empty the mario-stage ECR of images, which should result in a clean execution(i didn't do this in dev, and got an error, but emptying and reapplying worked fine).  

#### What are the relevant tickets?

* https://mitlibraries.atlassian.net/browse/IN-630

#### Requires Database Migrations?

NO

#### Includes new or updated dependencies?

NO
