### PR TITLE
Add ECR Repository for ArchivesSpace to Air Table Integration (ASATI) App Container

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,7 @@
+# CODEOWNERS file for mitlib-tf-workloads-ecr
+
+################################################################################
+# This repository is maintained by the MIT Libraries Infrastructure Team.
+* @mitlibraries/infraeng-terraform-reviewers
+
+# There are no individual code owners for this repository.

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,7 +1,20 @@
-# CODEOWNERS file for mitlib-tf-workloads-ecr
+# CODEOWNERS file (from GitHub template at
+# https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners)
+# Each line is a file pattern followed by one or more owners.
 
 ################################################################################
-# This repository is maintained by the MIT Libraries Infrastructure Team.
+# These owners will be the default owners for everything in the repo. Unless a
+# later match takes precedence, @cabutlermit will be requested for review when 
+# someone opens a pull request.This is commented out in favor of using a team
+# as the default (see below). It is left here as a comment to indicate the
+# primary expert for this code.
+# * @cabutlermit
+
+# Teams can be specified as code owners as well. Teams should be identified in
+# the format @org/team-name. Teams must have explicit write access to the 
+# repository.
 * @mitlibraries/infraeng-terraform-reviewers
 
-# There are no individual code owners for this repository.
+# We set the senior engineer in the team as the owner of the CODEOWNERS file as
+# a layer of protection for unauthorized changes.
+/.github/CODEOWNERS @cabutlermit

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: "v1.92.1"
+    rev: "v1.97.0"
     hooks:
       - id: terraform_fmt
         args:
@@ -12,7 +12,7 @@ repos:
       - id: terraform-docs-go
         args: ["markdown", "table", "--config", "./.terraform-docs.yaml", "--recursive", "--output-file", "README.md", "./"]
   - repo: https://github.com/bridgecrewio/checkov.git
-    rev: '3.2.219'
+    rev: '3.2.353'
     hooks:
       - id: checkov
         language_version: python3.11

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,7 +7,7 @@ repos:
           - --args=-recursive
       - id: terraform_validate
   - repo: https://github.com/terraform-docs/terraform-docs
-    rev: "v0.18.0"
+    rev: "v0.19.0"
     hooks:
       - id: terraform-docs-go
         args: ["markdown", "table", "--config", "./.terraform-docs.yaml", "--recursive", "--output-file", "README.md", "./"]

--- a/.terraform.lock.hcl
+++ b/.terraform.lock.hcl
@@ -5,6 +5,7 @@ provider "registry.terraform.io/hashicorp/aws" {
   version     = "5.62.0"
   constraints = "~> 5.0"
   hashes = [
+    "h1:8tevkFG+ea/sNZYiQ2GQ02hknPcWBukxkrpjRCodQC0=",
     "h1:X3LAZdkVhb/77gTlhPwKYCA9oblBCSu866fZDDOojPY=",
     "zh:1f366cbcda72fb123015439a42ab19f96e10ce4edb404273f4e1b7e06da20b73",
     "zh:25f098454a34b483279e0382b24b4f42e51c067222c6e797eda5d3ec33b9beb1",

--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ then replace all the ssm parameter references for `oidc_arn` with `aws_iam_openi
 | Name | Source | Version |
 |------|--------|---------|
 | ecr\_alma\_webhook\_lambdas | ./modules/ecr | n/a |
+| ecr\_asati | ./modules/ecr | n/a |
 | ecr\_bursar | ./modules/ecr | n/a |
 | ecr\_carbon | ./modules/ecr | n/a |
 | ecr\_creditcardslips | ./modules/ecr | n/a |
@@ -158,6 +159,10 @@ then replace all the ssm parameter references for `oidc_arn` with `aws_iam_openi
 | alma\_webhook\_lambdas\_makefile | Full contents of the Makefile for the alma-webhook-lambdas repo (allows devs to push to Dev account only) |
 | alma\_webhook\_lambdas\_prod\_promote\_workflow | Full contents of the prod-promote.yml for the alma-webhook-lambdas repo |
 | alma\_webhook\_lambdas\_stage\_build\_workflow | Full contents of the stage-build.yml for the alma-webhook-lambdas repo |
+| asati\_fargate\_dev\_build\_workflow | Full contents of the dev-build.yml for the asati repo |
+| asati\_fargate\_makefile | Full contents of the Makefile for the asati repo (allows devs to push to Dev account only) |
+| asati\_fargate\_prod\_promote\_workflow | Full contents of the prod-promote.yml for the asati repo |
+| asati\_fargate\_stage\_build\_workflow | Full contents of the stage-build.yml for the asati repo |
 | browsertrix\_dev\_build\_workflow | Full contents of the dev-build.yml for the browsertrix-harvester repo |
 | browsertrix\_makefile | Full contents of the Makefile for the browsertrix-harvester repo (allows devs to push to Dev account only) |
 | browsertrix\_prod\_promote\_workflow | Full contents of the prod-promote.yml for the browsertrix-harvester repo |

--- a/README.md
+++ b/README.md
@@ -89,6 +89,44 @@ then replace all the ssm parameter references for `oidc_arn` with `aws_iam_openi
 * [github-actions-push-to-aws-ecr-without-credentials-oidc](https://blog.tedivm.com/guides/2021/10/github-actions-push-to-aws-ecr-without-credentials-oidc/)
 * [about-security-hardening-with-openid-connect](https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/about-security-hardening-with-openid-connect#example-subject-claims)
 
+
+## Related Assets
+
+This is a core infrastructure repository that defines infrastructure related to ECS, ECR, and Fargate deployments. The following application infrastructure repositories depend on this repository:
+
+* [Alma Hook](https://github.com/MITLibraries/mitlib-tf-workloads-almahook)
+* [Alma Integrations](https://github.com/MITLibraries/mitlib-tf-workloads-patronload)
+    * [Alma Patron Load Application Container](https://github.com/MITLibraries/alma-patronload)
+* [ASATI](https://github.com/MITLibraries/mitlib-tf-workloads-asati)
+    * [ASATI Application Contaier](https://github.com/MITLibraries/asati)
+* [Carbon](https://github.com/MITLibraries/mitlib-tf-workloads-carbon)
+* [DSS](https://github.com/MITLibraries/mitlib-tf-workloads-dss)
+    * [DSpace Submission Service Application Container](https://github.com/MITLibraries/dspace-submission-service)
+    * [ETD](https://github.com/MITLibraries/mitlib-tf-workloads-etd)
+* [HRQB](https://github.com/MITLibraries/mitlib-tf-workloads-hrqb-loader)
+    * [HRQB Client](https://github.com/MITLibraries/hrqb-client)
+* [Matomo](https://github.com/MITLibraries/mitlib-tf-workloads-matomo)
+    * [Matomo Application Container](https://github.com/MITLibraries/docker-matomo)
+* [PPOD](https://github.com/MITLibraries/mitlib-tf-workloads-ppod)
+    * [PPOD Application Container](https://github.com/MITLibraries/ppod)
+* [Timdex](https://github.com/MITLibraries/mitlib-tf-workloads-timdex-infrastructure)
+    * [Timdex Application Container](https://github.com/MITLibraries/timdex)
+    * [Timdex Dataset API](https://github.com/MITLibraries/timdex-dataset-api)
+    * [Timdex Index Manager](https://github.com/MITLibraries/timdex-index-manager)
+    * [Timdex Pipeline Lambdas](https://github.com/MITLibraries/timdex-pipeline-lambdas)
+    * [Timdex UI](https://github.com/MITLibraries/timdex-ui)
+    * [Timdex Simulator](https://github.com/MITLibraries/timdex-simulator)
+* [WCD2Reshare](https://github.com/MITLibraries/mitlib-tf-workloads-wcd2reshare)
+    * [WCD2Reshare Appliation Container](https://github.com/MITLibraries/wcd2reshare)
+* [Wiley](https://github.com/MITLibraries/mitlib-tf-workloads-wiley)
+    * [Wiley Deposits Application Container](https://github.com/MITLibraries/mitlib-tf-workloads-wiley)
+
+## Maintainers
+
+* Owner: See [CODEOWNERS](./.github/CODEOWNERS)
+* Team: See [CODEOWNERS](./.github/CODEOWNERS)
+* Last Maintenance: 2025-01
+
 ## TF markdown is automatically inserted at the bottom of this file, nothing should be written beyond this point
 
 <!-- BEGIN_TF_DOCS -->

--- a/asati_ecr.tf
+++ b/asati_ecr.tf
@@ -5,13 +5,13 @@ locals {
 }
 module "ecr_asati" {
   source            = "./modules/ecr"
-  repo_name         = "docker-asati"
+  repo_name         = "asati"
   login_policy_arn  = aws_iam_policy.login.arn
   oidc_arn          = data.aws_ssm_parameter.oidc_arn.value
   environment       = var.environment
   tfoutput_ssm_path = var.tfoutput_ssm_path
   tags = {
-    app-repo = "docker-asati"
+    app-repo = "asati"
   }
 }
 

--- a/asati_ecr.tf
+++ b/asati_ecr.tf
@@ -1,0 +1,66 @@
+# ArchiveSpace AirTable Integration (asati) containers
+# This is a standard ECR for an ECS with a Fargate launch type
+locals {
+  ecr_asati = "asati-${var.environment}"
+}
+module "ecr_asati" {
+  source            = "./modules/ecr"
+  repo_name         = "docker-asati"
+  login_policy_arn  = aws_iam_policy.login.arn
+  oidc_arn          = data.aws_ssm_parameter.oidc_arn.value
+  environment       = var.environment
+  tfoutput_ssm_path = var.tfoutput_ssm_path
+  tags = {
+    app-repo = "docker-asati"
+  }
+}
+
+## Outputs to Terraform Cloud for devs ##
+
+## For asati application repo and ECR repository
+# Outputs in dev
+output "asati_fargate_dev_build_workflow" {
+  value = var.environment == "prod" || var.environment == "stage" ? null : templatefile("${path.module}/files/dev-build.tpl", {
+    region   = var.aws_region
+    role     = module.ecr_asati.gha_role
+    ecr      = module.ecr_asati.repository_name
+    function = ""
+    }
+  )
+  description = "Full contents of the dev-build.yml for the asati repo"
+}
+output "asati_fargate_makefile" {
+  value = var.environment == "prod" || var.environment == "stage" ? null : templatefile("${path.module}/files/makefile.tpl", {
+    ecr_name = module.ecr_asati.repository_name
+    ecr_url  = module.ecr_asati.repository_url
+    function = ""
+    }
+  )
+  description = "Full contents of the Makefile for the asati repo (allows devs to push to Dev account only)"
+}
+
+# Outputs in stage
+output "asati_fargate_stage_build_workflow" {
+  value = var.environment == "prod" || var.environment == "dev" ? null : templatefile("${path.module}/files/stage-build.tpl", {
+    region   = var.aws_region
+    role     = module.ecr_asati.gha_role
+    ecr      = module.ecr_asati.repository_name
+    function = ""
+    }
+  )
+  description = "Full contents of the stage-build.yml for the asati repo"
+}
+
+# Outputs after promotion to prod
+output "asati_fargate_prod_promote_workflow" {
+  value = var.environment == "stage" || var.environment == "dev" ? null : templatefile("${path.module}/files/prod-promote.tpl", {
+    region     = var.aws_region
+    role_stage = "${module.ecr_asati.repo_name}-gha-stage"
+    role_prod  = "${module.ecr_asati.repo_name}-gha-prod"
+    ecr_stage  = "${module.ecr_asati.repo_name}-stage"
+    ecr_prod   = "${module.ecr_asati.repo_name}-prod"
+    function   = ""
+    }
+  )
+  description = "Full contents of the prod-promote.yml for the asati repo"
+}

--- a/modules/ecr/.terraform.lock.hcl
+++ b/modules/ecr/.terraform.lock.hcl
@@ -5,6 +5,7 @@ provider "registry.terraform.io/hashicorp/aws" {
   version     = "5.62.0"
   constraints = "~> 5.0"
   hashes = [
+    "h1:8tevkFG+ea/sNZYiQ2GQ02hknPcWBukxkrpjRCodQC0=",
     "h1:X3LAZdkVhb/77gTlhPwKYCA9oblBCSu866fZDDOojPY=",
     "zh:1f366cbcda72fb123015439a42ab19f96e10ce4edb404273f4e1b7e06da20b73",
     "zh:25f098454a34b483279e0382b24b4f42e51c067222c6e797eda5d3ec33b9beb1",

--- a/modules/ecr/main.tf
+++ b/modules/ecr/main.tf
@@ -38,6 +38,7 @@ resource "aws_ecr_lifecycle_policy" "this" {
 ### Read-write permissions ECR repository
 data "aws_iam_policy_document" "rw_this" {
   #checkov:skip=CKV_AWS_111:This policy needs unconstrained CreateRepository privileges
+  #checkov:skip=CKV_AWS_356:This policy should allow "*" as a resource for restrictable actions
   statement {
     actions = [
       "ecr:CreateRepository",


### PR DESCRIPTION
#### Developer Checklist

- [X] The README contains any additional info needed outside of the terraform docs generated
- [X] Any special variables have values configured in AWS SSM
- [X] Stakeholder approval has been confirmed (or is not needed)

#### What does this PR do?

This PR creates the ArchivesSpace AirTable Integration (ASATI) application container infrastructure. The application source code is located in the https://github.com/MITLibraries/asati repository. ASATI is an AWS Fargate application.

How this addresses that need:

* Add a standard ECR for an ECS w/ Fargate launch type
* Update terraform.lock.hcl file
* Update the shared workflow for pre-commit configurations
* Supress checkov policy warning

#### What are the relevant tickets?

https://mitlibraries.atlassian.net/browse/IN-1147

#### Requires Database Migrations?

NO

#### Includes new or updated dependencies?

NO
