### PR TITLE
Add ECR Repository for DSpace Submission Composer App Container

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -13,7 +13,7 @@
 # Teams can be specified as code owners as well. Teams should be identified in
 # the format @org/team-name. Teams must have explicit write access to the 
 # repository.
-* @mitlibraries/infraeng-terraform-reviewers
+* @mitlibraries/infraeng
 
 # We set the senior engineer in the team as the owner of the CODEOWNERS file as
 # a layer of protection for unauthorized changes.

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: "v1.97.0"
+    rev: "v1.97.4"
     hooks:
       - id: terraform_fmt
         args:
@@ -12,8 +12,8 @@ repos:
       - id: terraform-docs-go
         args: ["markdown", "table", "--config", "./.terraform-docs.yaml", "--recursive", "--output-file", "README.md", "./"]
   - repo: https://github.com/bridgecrewio/checkov.git
-    rev: '3.2.353'
+    rev: '3.2.378'
     hooks:
       - id: checkov
-        language_version: python3.11
+        language_version: python3.12
         verbose: false

--- a/README.md
+++ b/README.md
@@ -98,8 +98,10 @@ This is a core infrastructure repository that defines infrastructure related to 
 * [Alma Integrations](https://github.com/MITLibraries/mitlib-tf-workloads-patronload)
     * [Alma Patron Load Application Container](https://github.com/MITLibraries/alma-patronload)
 * [ASATI](https://github.com/MITLibraries/mitlib-tf-workloads-asati)
-    * [ASATI Application Contaier](https://github.com/MITLibraries/asati)
+    * [ASATI Application Container](https://github.com/MITLibraries/asati)
 * [Carbon](https://github.com/MITLibraries/mitlib-tf-workloads-carbon)
+* [DSC](https://github.com/MITLibraries/mitlib-tf-workloads-dsc)
+    * [DSC Application Container](https://github.com/MITLibraries/dspace-submission-composer)
 * [DSS](https://github.com/MITLibraries/mitlib-tf-workloads-dss)
     * [DSpace Submission Service Application Container](https://github.com/MITLibraries/dspace-submission-service)
     * [ETD](https://github.com/MITLibraries/mitlib-tf-workloads-etd)
@@ -125,7 +127,7 @@ This is a core infrastructure repository that defines infrastructure related to 
 
 * Owner: See [CODEOWNERS](./.github/CODEOWNERS)
 * Team: See [CODEOWNERS](./.github/CODEOWNERS)
-* Last Maintenance: 2025-01
+* Last Maintenance: 2025-03
 
 ## TF markdown is automatically inserted at the bottom of this file, nothing should be written beyond this point
 
@@ -134,7 +136,7 @@ This is a core infrastructure repository that defines infrastructure related to 
 
 | Name | Version |
 |------|---------|
-| terraform | ~> 1.5 |
+| terraform | ~> 1.11 |
 | aws | ~> 5.0 |
 
 ## Providers
@@ -152,6 +154,7 @@ This is a core infrastructure repository that defines infrastructure related to 
 | ecr\_bursar | ./modules/ecr | n/a |
 | ecr\_carbon | ./modules/ecr | n/a |
 | ecr\_creditcardslips | ./modules/ecr | n/a |
+| ecr\_dsc | ./modules/ecr | n/a |
 | ecr\_dss | ./modules/ecr | n/a |
 | ecr\_hrqb\_client | ./modules/ecr | n/a |
 | ecr\_matomo | ./modules/ecr | n/a |
@@ -217,6 +220,10 @@ This is a core infrastructure repository that defines infrastructure related to 
 | creditcardslips\_makefile | Full contents of the Makefile for the alma-creditcardslips repo (allows devs to push to Dev account only) |
 | creditcardslips\_prod\_promote\_workflow | Full contents of the prod-promote.yml for the alma-creditcardslips repo |
 | creditcardslips\_stage\_build\_workflow | Full contents of the stage-build.yml for the alma-creditcardslips repo |
+| dsc\_fargate\_dev\_build\_workflow | Full contents of the dev-build.yml for the dsc repo |
+| dsc\_fargate\_makefile | Full contents of the Makefile for the dsc repo (allows devs to push to Dev account only) |
+| dsc\_fargate\_prod\_promote\_workflow | Full contents of the prod-promote.yml for the dsc repo |
+| dsc\_fargate\_stage\_build\_workflow | Full contents of the stage-build.yml for the dsc repo |
 | dss\_fargate\_dev\_build\_workflow | Full contents of the dev-build.yml for the dss repo |
 | dss\_fargate\_makefile | Full contents of the Makefile for the dss repo (allows devs to push to Dev account only) |
 | dss\_fargate\_prod\_promote\_workflow | Full contents of the prod-promote.yml for the dss repo |

--- a/dsc_ecr.tf
+++ b/dsc_ecr.tf
@@ -1,0 +1,67 @@
+# DSpace Submission Composer (dsc) containers
+# This is a standard ECR for an ECS with a Fargate launch type
+locals {
+  ecr_dsc = "dsc-${var.environment}"
+}
+
+module "ecr_dsc" {
+  source            = "./modules/ecr"
+  repo_name         = "dspace-submission-composer"
+  login_policy_arn  = aws_iam_policy.login.arn
+  oidc_arn          = data.aws_ssm_parameter.oidc_arn.value
+  environment       = var.environment
+  tfoutput_ssm_path = var.tfoutput_ssm_path
+  tags = {
+    app-repo = "dspace-submission-composer"
+  }
+}
+
+## Outputs to Terraform Cloud for devs ##
+
+## For dsc application repo and ECR repository
+# Outputs in dev
+output "dsc_fargate_dev_build_workflow" {
+  value = var.environment == "prod" || var.environment == "stage" ? null : templatefile("${path.module}/files/dev-build.tpl", {
+    region   = var.aws_region
+    role     = module.ecr_dsc.gha_role
+    ecr      = module.ecr_dsc.repository_name
+    function = ""
+    }
+  )
+  description = "Full contents of the dev-build.yml for the dsc repo"
+}
+output "dsc_fargate_makefile" {
+  value = var.environment == "prod" || var.environment == "stage" ? null : templatefile("${path.module}/files/makefile.tpl", {
+    ecr_name = module.ecr_dsc.repository_name
+    ecr_url  = module.ecr_dsc.repository_url
+    function = ""
+    }
+  )
+  description = "Full contents of the Makefile for the dsc repo (allows devs to push to Dev account only)"
+}
+
+# Outputs in stage
+output "dsc_fargate_stage_build_workflow" {
+  value = var.environment == "prod" || var.environment == "dev" ? null : templatefile("${path.module}/files/stage-build.tpl", {
+    region   = var.aws_region
+    role     = module.ecr_dsc.gha_role
+    ecr      = module.ecr_dsc.repository_name
+    function = ""
+    }
+  )
+  description = "Full contents of the stage-build.yml for the dsc repo"
+}
+
+# Outputs after promotion to prod
+output "dsc_fargate_prod_promote_workflow" {
+  value = var.environment == "stage" || var.environment == "dev" ? null : templatefile("${path.module}/files/prod-promote.tpl", {
+    region     = var.aws_region
+    role_stage = "${module.ecr_dsc.repo_name}-gha-stage"
+    role_prod  = "${module.ecr_dsc.repo_name}-gha-prod"
+    ecr_stage  = "${module.ecr_dsc.repo_name}-stage"
+    ecr_prod   = "${module.ecr_dsc.repo_name}-prod"
+    function   = ""
+    }
+  )
+  description = "Full contents of the prod-promote.yml for the dsc repo"
+}

--- a/modules/ecr/README.md
+++ b/modules/ecr/README.md
@@ -3,7 +3,7 @@
 
 | Name | Version |
 |------|---------|
-| terraform | ~> 1.5 |
+| terraform | ~> 1.11 |
 | aws | ~> 5.0 |
 
 ## Providers

--- a/modules/ecr/main.tf
+++ b/modules/ecr/main.tf
@@ -1,10 +1,10 @@
-################################################################################
-################################################################################
+##############################################################################
+##############################################################################
 # Create the ECR repository to store the ECS image(s) along with a lifecycle 
 # policy.
 resource "aws_ecr_repository" "this" {
   #checkov:skip=CKV_AWS_51:We do not currently use releases for this, but may choose to turn this on in the future
-  #checkov:skip=CKV_AWS_136:We dont store any private information in our images, encyption is unncessary
+  #checkov:skip=CKV_AWS_136:We do not store any private information in our images, encryption is unnecessary
   name = "${var.repo_name}-${var.environment}"
   image_scanning_configuration {
     scan_on_push = true
@@ -14,7 +14,7 @@ resource "aws_ecr_repository" "this" {
 }
 
 resource "aws_ecr_lifecycle_policy" "this" {
-  #checkov:skip=CKV_AWS_136:We dont store any private information in our images, encyption is unncessary 
+  #checkov:skip=CKV_AWS_136:We do not store any private information in our images, encryption is unnecessary 
   #checkov:skip=CKV_AWS_163:We do not use image scanning by AWS right now
   #checkov:skip=CKV_AWS_51:We do not currently use releases for this, but may choose to turn this on in the future
   repository = aws_ecr_repository.this.name

--- a/modules/ecr/versions.tf
+++ b/modules/ecr/versions.tf
@@ -3,7 +3,7 @@
 # Providers themselves are set in the `providers.tf` file.
 
 terraform {
-  required_version = "~> 1.5"
+  required_version = "~> 1.11"
 
   required_providers {
     aws = {

--- a/versions.tf
+++ b/versions.tf
@@ -3,7 +3,7 @@
 # Providers themselves are set in the `providers.tf` file.
 
 terraform {
-  required_version = "~> 1.5"
+  required_version = "~> 1.11"
 
   required_providers {
     aws = {


### PR DESCRIPTION
#### Developer Checklist

- [X] The README contains any additional info needed outside of the terraform docs generated
- [X] Any special variables have values configured in AWS SSM
- [X] Stakeholder approval has been confirmed (or is not needed)

#### What does this PR do?

This PR creates the DSpace Submission Composer (DSC) application ECR container infrastructure. The application source code is located in the https://github.com/MITLibraries/dspace-submission-composer repository. DSC is an AWS Fargate application.

* Add a standard ECR for an ECS w/ Fargate launch type
* Update to Terraform v11
* Update the shared workflow for pre-commit versions
* Update the CODEOWNERS file for MIT Libraries GH group security re-org
* Update README.md documentation
* Minor code clean-up

Side effects of this change:

None

Changes to be committed:
      modified:   .github/CODEOWNERS
      modified:   .pre-commit-config.yaml
      modified:   README.md
      new file:   dsc_ecr.tf
      modified:   modules/ecr/README.md
      modified:   modules/ecr/main.tf
      modified:   modules/ecr/versions.tf
      modified:   versions.tf

#### Helpful background context

It may make sense to have the Data Team move their repository to MITLibraries/dsc from MITLibraries/dspace-submission-composer. This would unify the naming convention to MITLibraries/{app name} with MITLibraries/mitlib-tf-workloads-{app name}. That would also unify all the resources and policies created in AWS. These changes would make documentation, code maintainability, and log analysis easier. It would not be a very large amount of work to perform this unification for existing ECR/ECS/Fargate/Lambda applications after agreeing upon it as an official standard for new applications.

#### What are the relevant tickets?

https://mitlibraries.atlassian.net/browse/IN-1082
* https://mitlibraries.atlassian.net/browse/IN-1161

#### Requires Database Migrations?

NO

#### Includes new or updated dependencies?

YES:
* Terraform v11
* Github Workflows
  * Workflow application versions upgraded to latest
  * python v3.12 for checkov
  
Note: It may be acceptable to not specify a python version for the latest (and future) versions of checkov. I think we can just run it with the system default for both GH/pre-commit actions and local dev machines. If this seems to be the case, I'll start removing the version constraint from the checkov GH/pre-commit actions in future PRs and we'll no longer need to update it as part of repository maintenance.
