### PR TITLE
Dev-to-Stage: Create ECR for s3-bagit-validator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@ override.tf.json
 # Include tfplan files to ignore the plan output of command: terraform plan -out=tfplan
 *tfplan*
 .DS_Store
+.tool-versions

--- a/README.md
+++ b/README.md
@@ -95,33 +95,36 @@ then replace all the ssm parameter references for `oidc_arn` with `aws_iam_openi
 This is a core infrastructure repository that defines infrastructure related to ECS, ECR, and Fargate deployments. The following application infrastructure repositories depend on this repository:
 
 * [Alma Hook](https://github.com/MITLibraries/mitlib-tf-workloads-almahook)
-* [Alma Integrations](https://github.com/MITLibraries/mitlib-tf-workloads-patronload)
-    * [Alma Patron Load Application Container](https://github.com/MITLibraries/alma-patronload)
+  * [Alma Webhook Lambdas](https://github.com/MITLibraries/alma-webhook-lambdas)
+* [Alma Patron Load](https://github.com/MITLibraries/mitlib-tf-workloads-patronload)
+  * [Alma Patron Load Application Container](https://github.com/MITLibraries/alma-patronload)
 * [ASATI](https://github.com/MITLibraries/mitlib-tf-workloads-asati)
-    * [ASATI Application Container](https://github.com/MITLibraries/asati)
+  * [ASATI Application Container](https://github.com/MITLibraries/asati)
 * [Carbon](https://github.com/MITLibraries/mitlib-tf-workloads-carbon)
 * [DSC](https://github.com/MITLibraries/mitlib-tf-workloads-dsc)
-    * [DSC Application Container](https://github.com/MITLibraries/dspace-submission-composer)
+  * [DSC Application Container](https://github.com/MITLibraries/dspace-submission-composer)
 * [DSS](https://github.com/MITLibraries/mitlib-tf-workloads-dss)
-    * [DSpace Submission Service Application Container](https://github.com/MITLibraries/dspace-submission-service)
-    * [ETD](https://github.com/MITLibraries/mitlib-tf-workloads-etd)
+  * [DSpace Submission Service Application Container](https://github.com/MITLibraries/dspace-submission-service)
+  * [ETD](https://github.com/MITLibraries/mitlib-tf-workloads-etd)
 * [HRQB](https://github.com/MITLibraries/mitlib-tf-workloads-hrqb-loader)
-    * [HRQB Client](https://github.com/MITLibraries/hrqb-client)
+  * [HRQB Client](https://github.com/MITLibraries/hrqb-client)
 * [Matomo](https://github.com/MITLibraries/mitlib-tf-workloads-matomo)
-    * [Matomo Application Container](https://github.com/MITLibraries/docker-matomo)
+  * [Matomo Application Container](https://github.com/MITLibraries/docker-matomo)
 * [PPOD](https://github.com/MITLibraries/mitlib-tf-workloads-ppod)
-    * [PPOD Application Container](https://github.com/MITLibraries/ppod)
-* [Timdex](https://github.com/MITLibraries/mitlib-tf-workloads-timdex-infrastructure)
-    * [Timdex Application Container](https://github.com/MITLibraries/timdex)
-    * [Timdex Dataset API](https://github.com/MITLibraries/timdex-dataset-api)
-    * [Timdex Index Manager](https://github.com/MITLibraries/timdex-index-manager)
-    * [Timdex Pipeline Lambdas](https://github.com/MITLibraries/timdex-pipeline-lambdas)
-    * [Timdex UI](https://github.com/MITLibraries/timdex-ui)
-    * [Timdex Simulator](https://github.com/MITLibraries/timdex-simulator)
+  * [PPOD Application Container](https://github.com/MITLibraries/ppod)
+* [CDPS](https://github.com/MITLibraries/mitlib-tf-workloads-cdps-storage)
+  * [S3 BagIt Validator](https://github.com/MITLibraries/s3-bagit-validator)
+* [TIMDEX](https://github.com/MITLibraries/mitlib-tf-workloads-timdex-infrastructure)
+  * [TIMDEX Application Container](https://github.com/MITLibraries/timdex)
+  * [TIMDEX Dataset API](https://github.com/MITLibraries/timdex-dataset-api)
+  * [TIMDEX Index Manager](https://github.com/MITLibraries/timdex-index-manager)
+  * [TIMDEX Pipeline Lambdas](https://github.com/MITLibraries/timdex-pipeline-lambdas)
+  * [TIMDEX UI](https://github.com/MITLibraries/timdex-ui)
+  * [TIMDEX Simulator](https://github.com/MITLibraries/timdex-simulator)
 * [WCD2Reshare](https://github.com/MITLibraries/mitlib-tf-workloads-wcd2reshare)
-    * [WCD2Reshare Appliation Container](https://github.com/MITLibraries/wcd2reshare)
-* [Wiley](https://github.com/MITLibraries/mitlib-tf-workloads-wiley)
-    * [Wiley Deposits Application Container](https://github.com/MITLibraries/mitlib-tf-workloads-wiley)
+  * [WCD2Reshare Application Container](https://github.com/MITLibraries/wcd2reshare)
+* **DEPRECATED**: [Wiley](https://github.com/MITLibraries/mitlib-tf-workloads-wiley)
+  * **DEPRECATED**: [Wiley Deposits Application Container](https://github.com/MITLibraries/mitlib-tf-workloads-wiley)
 
 ## Maintainers
 
@@ -153,6 +156,7 @@ This is a core infrastructure repository that defines infrastructure related to 
 | ecr\_asati | ./modules/ecr | n/a |
 | ecr\_bursar | ./modules/ecr | n/a |
 | ecr\_carbon | ./modules/ecr | n/a |
+| ecr\_cdps\_s3\_bagit\_validator | ./modules/ecr | n/a |
 | ecr\_creditcardslips | ./modules/ecr | n/a |
 | ecr\_dsc | ./modules/ecr | n/a |
 | ecr\_dss | ./modules/ecr | n/a |
@@ -252,6 +256,10 @@ This is a core infrastructure repository that defines infrastructure related to 
 | ppod\_makefile | Full contents of the Makefile for the ppod repo (allows devs to push to Dev account only) |
 | ppod\_prod\_promote\_workflow | Full contents of the prod-promote.yml for the ppod repo |
 | ppod\_stage\_build\_workflow | Full contents of the stage-build.yml for the ppod repo |
+| s3\_bagit\_validator\_dev\_build\_workflow | Full contents of the dev-build.yml for the s3-bagit-validator repo |
+| s3\_bagit\_validator\_makefile | Full contents of the Makefile for the s3-bagit-validator repo (allows devs to push to Dev account only) |
+| s3\_bagit\_validator\_prod\_promote\_workflow | Full contents of the prod-promote.yml for the s3-bagit-validator repo |
+| s3\_bagit\_validator\_stage\_build\_workflow | Full contents of the stage-build.yml for the s3-bagit-validator repo |
 | sapinvoices\_dev\_build\_workflow | Full contents of the dev-build.yml for the alma-sapinvoices repo |
 | sapinvoices\_makefile | Full contents of the Makefile for the alma-sapinvoices repo (allows devs to push to Dev account only) |
 | sapinvoices\_prod\_promote\_workflow | Full contents of the prod-promote.yml for the alma-sapinvoices repo |

--- a/cdps.tf
+++ b/cdps.tf
@@ -1,0 +1,68 @@
+## CDPS related ECRs
+
+# s3-bagit-validator for the CDPS project
+# Since this is a Lambda function, we need to set the function name now in 
+# order to build the correct files.
+locals {
+  ecr_cdps_s3_bagit_validator_function_name = "s3-bagit-validator-${var.environment}"
+}
+
+module "ecr_cdps_s3_bagit_validator" {
+  source            = "./modules/ecr"
+  repo_name         = "s3-bagit-validator"
+  login_policy_arn  = aws_iam_policy.login.arn
+  oidc_arn          = data.aws_ssm_parameter.oidc_arn.value
+  environment       = var.environment
+  tfoutput_ssm_path = var.tfoutput_ssm_path
+  tags = {
+    app-repo = "s3-bagit-validator"
+  }
+}
+
+## For s3-bagit-validator application repo and ECR repository
+# Outputs in dev
+output "s3_bagit_validator_dev_build_workflow" {
+  value = var.environment == "prod" || var.environment == "stage" ? null : templatefile("${path.module}/files/dev-build.tpl", {
+    region   = var.aws_region
+    role     = module.ecr_cdps_s3_bagit_validator.gha_role
+    ecr      = module.ecr_cdps_s3_bagit_validator.repository_name
+    function = local.ecr_cdps_s3_bagit_validator_function_name
+    }
+  )
+  description = "Full contents of the dev-build.yml for the s3-bagit-validator repo"
+}
+output "s3_bagit_validator_makefile" {
+  value = var.environment == "prod" || var.environment == "stage" ? null : templatefile("${path.module}/files/makefile.tpl", {
+    ecr_name = module.ecr_cdps_s3_bagit_validator.repository_name
+    ecr_url  = module.ecr_cdps_s3_bagit_validator.repository_url
+    function = local.ecr_cdps_s3_bagit_validator_function_name
+    }
+  )
+  description = "Full contents of the Makefile for the s3-bagit-validator repo (allows devs to push to Dev account only)"
+}
+
+# Outputs in stage
+output "s3_bagit_validator_stage_build_workflow" {
+  value = var.environment == "prod" || var.environment == "dev" ? null : templatefile("${path.module}/files/stage-build.tpl", {
+    region   = var.aws_region
+    role     = module.ecr_cdps_s3_bagit_validator.gha_role
+    ecr      = module.ecr_cdps_s3_bagit_validator.repository_name
+    function = local.ecr_cdps_s3_bagit_validator_function_name
+    }
+  )
+  description = "Full contents of the stage-build.yml for the s3-bagit-validator repo"
+}
+
+# Outputs after promotion to prod
+output "s3_bagit_validator_prod_promote_workflow" {
+  value = var.environment == "stage" || var.environment == "dev" ? null : templatefile("${path.module}/files/prod-promote.tpl", {
+    region     = var.aws_region
+    role_stage = "${module.ecr_cdps_s3_bagit_validator.repo_name}-gha-stage"
+    role_prod  = "${module.ecr_cdps_s3_bagit_validator.repo_name}-gha-prod"
+    ecr_stage  = "${module.ecr_cdps_s3_bagit_validator.repo_name}-stage"
+    ecr_prod   = "${module.ecr_cdps_s3_bagit_validator.repo_name}-prod"
+    function   = local.ecr_cdps_s3_bagit_validator_function_name
+    }
+  )
+  description = "Full contents of the prod-promote.yml for the s3-bagit-validator repo"
+}

--- a/modules/ecr/ssm_outputs.tf
+++ b/modules/ecr/ssm_outputs.tf
@@ -9,9 +9,7 @@ resource "aws_ssm_parameter" "ecr_repository_name" {
   name        = "${var.tfoutput_ssm_path}/${var.repo_name}/ecr-repository-name"
   value       = aws_ecr_repository.this.name
   description = "The name of the ${var.repo_name} ECR repository"
-  overwrite   = true
-
-  tags = var.tags
+  tags        = var.tags
 }
 
 # ecr repository_url
@@ -23,9 +21,7 @@ resource "aws_ssm_parameter" "ecr_repository_url" {
   name        = "${var.tfoutput_ssm_path}/${var.repo_name}/ecr-repository-url"
   value       = aws_ecr_repository.this.repository_url
   description = "The URL of the ${var.repo_name} ECR repository"
-  overwrite   = true
-
-  tags = var.tags
+  tags        = var.tags
 }
 
 # ecr role so that we can add the updatefunctioncode to it after the lambda itself is created
@@ -37,7 +33,5 @@ resource "aws_ssm_parameter" "gha_role" {
   name        = "${var.tfoutput_ssm_path}/${var.repo_name}/gha-role"
   value       = aws_iam_role.gha_this.name
   description = "Github action role used to update the ${var.repo_name} ECR repository"
-  overwrite   = true
-
-  tags = var.tags
+  tags        = var.tags
 }


### PR DESCRIPTION
## Developer Checklist

- [x] The README contains any additional info needed outside of the terraform docs generated
- [x] Any special variables have values configured in AWS SSM
- [x] Stakeholder approval has been confirmed (or is not needed)

## What does this PR do?

* Create a new set of ECR-related resources for the s3-bagit-validator application that will be part of CDPS
* Remove the `overwrite = true` lines from the Terraform managed ssm_outputs (that line is deprecated in the current version of the AWS Provider)
* Clean up the README

## Helpful background context

As part of CDPS and directly related to the Isilon Replacement project, this starts the build out of a new app for validating AIPs stored in S3 as part of the Archivematica implementation.

## What are the relevant tickets?

* [IR-177](https://mitlibraries.atlassian.net/browse/IR-177)

## Requires Database Migrations?

NO

## Includes new or updated dependencies?

NO


[IR-177]: https://mitlibraries.atlassian.net/browse/IR-177?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ