### PR TITLE
Dev-to-Stage: Create ECR Repository for CDPS-CURT (re-do)

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,6 @@ then replace all the ssm parameter references for `oidc_arn` with `aws_iam_openi
 * [github-actions-push-to-aws-ecr-without-credentials-oidc](https://blog.tedivm.com/guides/2021/10/github-actions-push-to-aws-ecr-without-credentials-oidc/)
 * [about-security-hardening-with-openid-connect](https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/about-security-hardening-with-openid-connect#example-subject-claims)
 
-
 ## Related Assets
 
 This is a core infrastructure repository that defines infrastructure related to ECS, ECR, and Fargate deployments. The following application infrastructure repositories depend on this repository:
@@ -101,6 +100,9 @@ This is a core infrastructure repository that defines infrastructure related to 
 * [ASATI](https://github.com/MITLibraries/mitlib-tf-workloads-asati)
   * [ASATI Application Container](https://github.com/MITLibraries/asati)
 * [Carbon](https://github.com/MITLibraries/mitlib-tf-workloads-carbon)
+* [CDPS](https://github.com/MITLibraries/mitlib-tf-workloads-cdps-storage)
+  * [S3 BagIt Validator](https://github.com/MITLibraries/s3-bagit-validator)
+  * [CDPS CURT](https://github.com/MITLibraries/cdps-curt)
 * [DSC](https://github.com/MITLibraries/mitlib-tf-workloads-dsc)
   * [DSC Application Container](https://github.com/MITLibraries/dspace-submission-composer)
 * [DSS](https://github.com/MITLibraries/mitlib-tf-workloads-dss)
@@ -112,8 +114,6 @@ This is a core infrastructure repository that defines infrastructure related to 
   * [Matomo Application Container](https://github.com/MITLibraries/docker-matomo)
 * [PPOD](https://github.com/MITLibraries/mitlib-tf-workloads-ppod)
   * [PPOD Application Container](https://github.com/MITLibraries/ppod)
-* [CDPS](https://github.com/MITLibraries/mitlib-tf-workloads-cdps-storage)
-  * [S3 BagIt Validator](https://github.com/MITLibraries/s3-bagit-validator)
 * [TIMDEX](https://github.com/MITLibraries/mitlib-tf-workloads-timdex-infrastructure)
   * [TIMDEX Application Container](https://github.com/MITLibraries/timdex)
   * [TIMDEX Dataset API](https://github.com/MITLibraries/timdex-dataset-api)
@@ -156,6 +156,7 @@ This is a core infrastructure repository that defines infrastructure related to 
 | ecr\_asati | ./modules/ecr | n/a |
 | ecr\_bursar | ./modules/ecr | n/a |
 | ecr\_carbon | ./modules/ecr | n/a |
+| ecr\_cdps\_curt | ./modules/ecr | n/a |
 | ecr\_cdps\_s3\_bagit\_validator | ./modules/ecr | n/a |
 | ecr\_creditcardslips | ./modules/ecr | n/a |
 | ecr\_dsc | ./modules/ecr | n/a |
@@ -220,6 +221,10 @@ This is a core infrastructure repository that defines infrastructure related to 
 | carbon\_makefile | Full contents of the Makefile for the carbon repo (allows devs to push to Dev account only) |
 | carbon\_prod\_promote\_workflow | Full contents of the prod-promote.yml for the carbon repo |
 | carbon\_stage\_build\_workflow | Full contents of the stage-build.yml for the carbon repo |
+| cdps\_curt\_dev\_build\_workflow | Full contents of the dev-build.yml for the cdps-curt repo |
+| cdps\_curt\_makefile | Full contents of the Makefile for the cdps-curt repo (allows devs to push to Dev account only) |
+| cdps\_curt\_prod\_promote\_workflow | Full contents of the prod-promote.yml for the cdps-curt repo |
+| cdps\_curt\_stage\_build\_workflow | Full contents of the stage-build.yml for the cdps-curt repo |
 | creditcardslips\_dev\_build\_workflow | Full contents of the dev-build.yml for the alma-creditcardslips repo |
 | creditcardslips\_makefile | Full contents of the Makefile for the alma-creditcardslips repo (allows devs to push to Dev account only) |
 | creditcardslips\_prod\_promote\_workflow | Full contents of the prod-promote.yml for the alma-creditcardslips repo |

--- a/cdps.tf
+++ b/cdps.tf
@@ -1,5 +1,6 @@
 ## CDPS related ECRs
 
+##############################################################################
 # s3-bagit-validator for the CDPS project
 # Since this is a Lambda function, we need to set the function name now in 
 # order to build the correct files.
@@ -65,4 +66,69 @@ output "s3_bagit_validator_prod_promote_workflow" {
     }
   )
   description = "Full contents of the prod-promote.yml for the s3-bagit-validator repo"
+}
+
+
+##############################################################################
+# cdps-curt for the CDPS project
+# This is a Fargate task, so no need for a Lambda function name
+
+module "ecr_cdps_curt" {
+  source            = "./modules/ecr"
+  repo_name         = "cdps-curt"
+  login_policy_arn  = aws_iam_policy.login.arn
+  oidc_arn          = data.aws_ssm_parameter.oidc_arn.value
+  environment       = var.environment
+  tfoutput_ssm_path = var.tfoutput_ssm_path
+  tags = {
+    app-repo = "cdps-curt"
+  }
+}
+
+## For cdps-curt application repo and ECR repository
+# Outputs in dev
+output "cdps_curt_dev_build_workflow" {
+  value = var.environment == "prod" || var.environment == "stage" ? null : templatefile("${path.module}/files/dev-build.tpl", {
+    region   = var.aws_region
+    role     = module.ecr_cdps_curt.gha_role
+    ecr      = module.ecr_cdps_curt.repository_name
+    function = ""
+    }
+  )
+  description = "Full contents of the dev-build.yml for the cdps-curt repo"
+}
+output "cdps_curt_makefile" {
+  value = var.environment == "prod" || var.environment == "stage" ? null : templatefile("${path.module}/files/makefile.tpl", {
+    ecr_name = module.ecr_cdps_curt.repository_name
+    ecr_url  = module.ecr_cdps_curt.repository_url
+    function = ""
+    }
+  )
+  description = "Full contents of the Makefile for the cdps-curt repo (allows devs to push to Dev account only)"
+}
+
+# Outputs in stage
+output "cdps_curt_stage_build_workflow" {
+  value = var.environment == "prod" || var.environment == "dev" ? null : templatefile("${path.module}/files/stage-build.tpl", {
+    region   = var.aws_region
+    role     = module.ecr_cdps_curt.gha_role
+    ecr      = module.ecr_cdps_curt.repository_name
+    function = ""
+    }
+  )
+  description = "Full contents of the stage-build.yml for the cdps-curt repo"
+}
+
+# Outputs after promotion to prod
+output "cdps_curt_prod_promote_workflow" {
+  value = var.environment == "stage" || var.environment == "dev" ? null : templatefile("${path.module}/files/prod-promote.tpl", {
+    region     = var.aws_region
+    role_stage = "${module.ecr_cdps_curt.repo_name}-gha-stage"
+    role_prod  = "${module.ecr_cdps_curt.repo_name}-gha-prod"
+    ecr_stage  = "${module.ecr_cdps_curt.repo_name}-stage"
+    ecr_prod   = "${module.ecr_cdps_curt.repo_name}-prod"
+    function   = ""
+    }
+  )
+  description = "Full contents of the prod-promote.yml for the cdps-curt repo"
 }


### PR DESCRIPTION
## Developer Checklist

- [x] The README contains any additional info needed outside of the terraform docs generated
- [x] Any special variables have values configured in AWS SSM
- [x] Stakeholder approval has been confirmed (or is not needed)

## What does this PR do?

* Create a new ECR repository and associated roles for the cdps-curt application
* Update the README

## Helpful background context

There is a new application, [cdps-curt](https://github.com/MITLibraries/cdps-curt), that will generate cost and usage reports for CDPS resources in AWS. It will run as a Fargate task, so it needs and ECR Repository.

The last PR was mistakenly merged to `main` instead of to `stage`.

## What are the relevant tickets?

* [IN-1207](https://mitlibraries.atlassian.net/browse/IN-1207)

## Requires Database Migrations?

NO

## Includes new or updated dependencies?

NO


[IN-1207]: https://mitlibraries.atlassian.net/browse/IN-1207?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ