### PR TITLE
Dev-to-Stage: Update browsertrix-harvester Outputs

### DIFF
--- a/timdex_ecrs.tf
+++ b/timdex_ecrs.tf
@@ -258,14 +258,10 @@ module "ecr_timdex_browsertrix" {
     app-repo = "timdex-infrastructure-browsertrix"
   }
 }
-# NEED TO FIX THE MISSPELLING!!!
-moved {
-  from = module.ecr_timdex_broswertrix
-  to   = module.ecr_timdex_browsertrix
-}
+
 # Outputs in dev
 output "browsertrix_dev_build_workflow" {
-  value = var.environment == "prod" || var.environment == "stage" ? null : templatefile("${path.module}/files/dev-build.tpl", {
+  value = var.environment == "prod" || var.environment == "stage" ? null : templatefile("${path.module}/files/dev-build-cpu-arch.tpl", {
     region   = var.aws_region
     role     = module.ecr_timdex_browsertrix.gha_role
     ecr      = module.ecr_timdex_browsertrix.repository_name
@@ -274,13 +270,9 @@ output "browsertrix_dev_build_workflow" {
   )
   description = "Full contents of the dev-build.yml for the browsertrix-harvester repo"
 }
-# NEED TO FIX THE MISSPELLING!!!
-moved {
-  from = output.broswertrix_dev_build_workflow
-  to   = output.browsertrix_dev_build_workflow
-}
+
 output "browsertrix_makefile" {
-  value = var.environment == "prod" || var.environment == "stage" ? null : templatefile("${path.module}/files/makefile.tpl", {
+  value = var.environment == "prod" || var.environment == "stage" ? null : templatefile("${path.module}/files/makefile-cpu-arch.tpl", {
     ecr_name = module.ecr_timdex_browsertrix.repository_name
     ecr_url  = module.ecr_timdex_browsertrix.repository_url
     function = ""
@@ -288,14 +280,10 @@ output "browsertrix_makefile" {
   )
   description = "Full contents of the Makefile for the browsertrix-harvester repo (allows devs to push to Dev account only)"
 }
-# NEED TO FIX THE MISSPELLING!!!
-moved {
-  from = output.broswertrix_makefile
-  to   = output.browsertrix_makefile
-}
+
 # Outputs in stage
 output "browsertrix_stage_build_workflow" {
-  value = var.environment == "prod" || var.environment == "dev" ? null : templatefile("${path.module}/files/stage-build.tpl", {
+  value = var.environment == "prod" || var.environment == "dev" ? null : templatefile("${path.module}/files/stage-build-cpu-arch.tpl", {
     region   = var.aws_region
     role     = module.ecr_timdex_browsertrix.gha_role
     ecr      = module.ecr_timdex_browsertrix.repository_name
@@ -304,14 +292,10 @@ output "browsertrix_stage_build_workflow" {
   )
   description = "Full contents of the stage-build.yml for the browsertrix-harvester repo"
 }
-# NEED TO FIX THE MISSPELLING!!!
-moved {
-  from = output.broswertrix_stage_build_workflow
-  to   = output.browsertrix_stage_build_workflow
-}
+
 # Outputs after promotion to prod
 output "browsertrix_prod_promote_workflow" {
-  value = var.environment == "stage" || var.environment == "dev" ? null : templatefile("${path.module}/files/prod-promote.tpl", {
+  value = var.environment == "stage" || var.environment == "dev" ? null : templatefile("${path.module}/files/prod-promote-cpu-arch.tpl", {
     region     = var.aws_region
     role_stage = "${module.ecr_timdex_browsertrix.repo_name}-gha-stage"
     role_prod  = "${module.ecr_timdex_browsertrix.repo_name}-gha-prod"
@@ -321,11 +305,6 @@ output "browsertrix_prod_promote_workflow" {
     }
   )
   description = "Full contents of the prod-promote.yml for the browsertrix-harvester repo"
-}
-# NEED TO FIX THE MISSPELLING!!!
-moved {
-  from = output.broswertrix_prod_promote_workflow
-  to   = output.browsertrix_prod_promote_workflow
 }
 
 


### PR DESCRIPTION
## Developer Checklist

- [x] The README contains any additional info needed outside of the terraform docs generated
- [x] Any special variables have values configured in AWS SSM
- [x] Stakeholder approval has been confirmed (or is not needed)

## What does this PR do?

* Fix the `Makefile` template based on lessons-learned during the update of the marimo-launcher application
* Update the browsertrix-harvester outputs to use the new template files for the workflows and `Makefile`

## Helpful background context

This is the second application repository upgrade, so we expect that everything will work smoothly. There are no changes to anything in AWS, just updated Terraform Cloud outputs.

## What are the relevant tickets?

* [IN-1500](https://mitlibraries.atlassian.net/browse/IN-1500)

## Requires Database Migrations?

NO

## Includes new or updated dependencies?

NO


[IN-1500]: https://mitlibraries.atlassian.net/browse/IN-1500?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ